### PR TITLE
fix(snap): install desktop file and icon into snap staging tree

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,16 @@ parts:
       - libglib2.0-0
       - adwaita-icon-theme
 
+  desktop-assets:
+    plugin: dump
+    source: .
+    organize:
+      packaging/deb/dplayer-gui.desktop: usr/share/applications/discogs-spinner.desktop
+      assets/icons/discogs-player.svg: usr/share/icons/hicolor/scalable/apps/discogs-spinner.svg
+    stage:
+      - usr/share/applications/discogs-spinner.desktop
+      - usr/share/icons/hicolor/scalable/apps/discogs-spinner.svg
+
 apps:
   spinner-for-discogs:
     command: bin/dplayer-gui

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,10 @@ parts:
     stage:
       - usr/share/applications/discogs-spinner.desktop
       - usr/share/icons/hicolor/scalable/apps/discogs-spinner.svg
+    override-build: |
+      craftctl default
+      sed -i 's|^Exec=.*|Exec=spinner-for-discogs|' \
+        "${CRAFT_PART_INSTALL}/usr/share/applications/discogs-spinner.desktop"
 
 apps:
   spinner-for-discogs:


### PR DESCRIPTION
## Summary

Fixes the Snap publish CI failure:
```
Failed to generate desktop file 'usr/share/applications/discogs-spinner.desktop': file does not exist
```

The `snapcraft.yaml` referenced `desktop: usr/share/applications/discogs-spinner.desktop` but nothing staged that file into the snap. Added a `desktop-assets` part using the `dump` plugin to install:
- `packaging/deb/dplayer-gui.desktop` → `usr/share/applications/discogs-spinner.desktop`
- `assets/icons/discogs-player.svg` → `usr/share/icons/hicolor/scalable/apps/discogs-spinner.svg`

## Test plan
- [ ] Snap publish CI passes after merge
- [ ] `snap install spinner-for-discogs` installs with correct icon and desktop launcher

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_