### PR TITLE
fix(snap): patch desktop Exec at pre-organize path

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
     override-build: |
       craftctl default
       sed -i 's|^Exec=.*|Exec=spinner-for-discogs|' \
-        "${CRAFT_PART_INSTALL}/usr/share/applications/discogs-spinner.desktop"
+        "${CRAFT_PART_INSTALL}/packaging/deb/dplayer-gui.desktop"
 
 apps:
   spinner-for-discogs:


### PR DESCRIPTION
## Summary

Fixes Snap publish CI failure #2:
```
sed: can't read .../install/usr/share/applications/discogs-spinner.desktop: No such file or directory
```

`organize` runs **after** `override-build`, so during the build step the file is still at its source path (`packaging/deb/dplayer-gui.desktop`), not the organized destination. Changed `sed` to patch the pre-organize path — `organize` then renames it to the correct location.

## Test plan
- [ ] Snap publish CI passes after merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_