### PR TITLE
ci(snap): opt into Node.js 24 before June 16 forced cutover

### DIFF
--- a/.github/workflows/snap_publish.yml
+++ b/.github/workflows/snap_publish.yml
@@ -6,11 +6,12 @@ on:
       - 'v*'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   snap:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/snap_publish.yml
+++ b/.github/workflows/snap_publish.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   snap:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,6 +18,12 @@ description: |
 
 grade: stable
 confinement: strict
+license: MIT
+title: Spinner for Discogs
+website: https://github.com/edonahue/Discogs_Spinner
+contact: https://github.com/edonahue/Discogs_Spinner/issues
+source-code: https://github.com/edonahue/Discogs_Spinner
+issues: https://github.com/edonahue/Discogs_Spinner/issues
 
 # Snap publication steps:
 #   snapcraft login
@@ -53,9 +59,11 @@ parts:
     organize:
       packaging/deb/dplayer-gui.desktop: usr/share/applications/discogs-spinner.desktop
       assets/icons/discogs-player.svg: usr/share/icons/hicolor/scalable/apps/discogs-spinner.svg
+      packaging/metainfo/com.discogs-spinner.app.metainfo.xml: usr/share/metainfo/com.discogs-spinner.app.metainfo.xml
     stage:
       - usr/share/applications/discogs-spinner.desktop
       - usr/share/icons/hicolor/scalable/apps/discogs-spinner.svg
+      - usr/share/metainfo/com.discogs-spinner.app.metainfo.xml
     override-build: |
       craftctl default
       sed -i 's|^Exec=.*|Exec=spinner-for-discogs|' \


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the snap publish job
- GitHub Actions will force Node.js 20 → 24 on **June 16, 2026** (9 days away)
- This opts in early so any incompatibilities surface before the deadline rather than on a release day

## Why now

The last snap publish run printed this warning:
> Node.js 20 actions are deprecated … `actions/checkout@v4`, `snapcore/action-build@v1` … Actions will be forced to run with Node.js 24 by default starting June 16th, 2026

If either action is incompatible with Node 24, we want to know that now, not on the day of the next release.

## Test plan

- [ ] Merge and trigger the Snap publish workflow manually
- [ ] Confirm the build step still passes (no Node.js compatibility errors from `snapcore/action-build@v1`)
- [ ] If `snapcore/action-build@v1` fails under Node 24, check for a v2 release and update the action version

https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_