### PR TITLE
ci: opt all workflows into Node.js 24 before June 16 deadline

### DIFF
--- a/.github/workflows/core_plus_ci.yml
+++ b/.github/workflows/core_plus_ci.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepublish-hygiene:
     name: Prepublish Hygiene

--- a/.github/workflows/installer_build.yml
+++ b/.github/workflows/installer_build.yml
@@ -21,6 +21,9 @@ on:
         required: false
         default: "dev"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # ---------------------------------------------------------------------------
   # Phase B: Build the PyInstaller API sidecar on each platform

--- a/.github/workflows/pilot_validation_windows_macos.yml
+++ b/.github/workflows/pilot_validation_windows_macos.yml
@@ -13,6 +13,9 @@ on:
       - "pyproject.toml"
       - "requirements.txt"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   clean-runner-validation:
     name: Clean Runner Validation (${{ matrix.os }})

--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-release-artifacts:
     name: Build Release Artifacts (${{ matrix.os }})

--- a/.github/workflows/windows_msi_smoke.yml
+++ b/.github/workflows/windows_msi_smoke.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "17 5 * * *"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   windows-msi-smoke:
     name: Windows MSI smoke install


### PR DESCRIPTION
## Summary

GitHub Actions forces the Node.js 20 action runtime → Node.js 24 on **June 16, 2026** (9 days away). This adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the top-level workflow `env:` to the 5 workflows that were missing it.

`snap_publish.yml` is handled in PR #6.

| Workflow | Jobs covered |
|---|---|
| `core_plus_ci.yml` | 4 (prepublish-hygiene, test-core, test-plus, docs) |
| `installer_build.yml` | 4+ (build-linux, build-windows, build-macos, publish-release) |
| `pilot_validation_windows_macos.yml` | 2 (Windows + macOS) |
| `tagged_release.yml` | 2+ |
| `windows_msi_smoke.yml` | 1 |

**What this does:** Forces the action runner to execute all action JavaScript with Node.js 24 now, surfacing any incompatibilities before June 16 rather than discovering them on a release day.

**What this does NOT change:** `actions/setup-node@v4` with `node-version: '20'` in `installer_build.yml` and `windows_msi_smoke.yml` — that installs Node 20 for the Tauri build, which is separate from the action runner.

## Test plan

- [ ] Core Plus CI passes on this PR (covers `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4` under Node 24)
- [ ] After merge: monitor next `installer_build.yml` run for `dtolnay/rust-toolchain` and `swatinem/rust-cache` under Node 24
- [ ] If any community action fails: add `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` to that specific job as a fallback

https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_