### PR TITLE
Fix daily CI failure: remove msix (not a valid Tauri v2 target)

### DIFF
--- a/.github/workflows/installer_build.yml
+++ b/.github/workflows/installer_build.yml
@@ -116,7 +116,7 @@ jobs:
             tauri_targets: dmg
           - os: windows-2022
             target_triple: x86_64-pc-windows-msvc
-            tauri_targets: msi,nsis,msix
+            tauri_targets: msi,nsis
 
     steps:
       - name: Checkout
@@ -277,7 +277,6 @@ jobs:
           path: |
             desktop_shell/src-tauri/target/${{ matrix.target_triple }}/release/bundle/msi/*.msi
             desktop_shell/src-tauri/target/${{ matrix.target_triple }}/release/bundle/nsis/*.exe
-            desktop_shell/src-tauri/target/${{ matrix.target_triple }}/release/bundle/msix/*.msix
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
@@ -443,7 +442,6 @@ jobs:
           mapfile -d '' -t dmgs < <(find "$RELEASE_RAW_DIR"/installer-macos-* -type f -name '*.dmg' -print0 | sort -z)
           mapfile -d '' -t msis < <(find "$RELEASE_RAW_DIR"/installer-windows-* -type f -name '*.msi' -print0 | sort -z)
           mapfile -d '' -t exes < <(find "$RELEASE_RAW_DIR"/installer-windows-* -type f -name '*.exe' -print0 | sort -z)
-          mapfile -d '' -t msixs < <(find "$RELEASE_RAW_DIR"/installer-windows-* -type f -name '*.msix' -print0 | sort -z)
 
           copy_asset_group "discogs-spinner-gtk4_${RELEASE_VERSION}_amd64.deb" "${gtk_debs[@]}"
           copy_asset_group "discogs-spinner-tauri_${RELEASE_VERSION}_amd64.deb" "${linux_debs[@]}"
@@ -460,9 +458,6 @@ jobs:
           for exe in "${exes[@]}"; do
             copy_single_asset "$exe" "$(basename "$exe")"
           done
-          for msix in "${msixs[@]}"; do
-            copy_single_asset "$msix" "$(basename "$msix")"
-          done
 
       - name: Validate release asset inventory
         shell: bash
@@ -474,7 +469,6 @@ jobs:
           ls "$RELEASE_PUBLISH_DIR"/*.dmg >/dev/null
           ls "$RELEASE_PUBLISH_DIR"/*.msi >/dev/null
           ls "$RELEASE_PUBLISH_DIR"/*.exe >/dev/null
-          ls "$RELEASE_PUBLISH_DIR"/*.msix >/dev/null
           ls "$RELEASE_PUBLISH_DIR"/*.AppImage >/dev/null
 
       - name: Generate SHA256 checksums
@@ -553,6 +547,5 @@ jobs:
           grep -F ".dmg" <<<"$asset_names"
           grep -F ".msi" <<<"$asset_names"
           grep -F ".exe" <<<"$asset_names"
-          grep -F ".msix" <<<"$asset_names"
           grep -Fx "CHECKSUMS-INSTALLERS.txt" <<<"$asset_names"
           grep -Fx "INSTALLER-MANIFEST.txt" <<<"$asset_names"

--- a/desktop_shell/src-tauri/tauri.conf.json
+++ b/desktop_shell/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["deb", "appimage", "msi", "nsis", "dmg", "msix"],
+    "targets": ["deb", "appimage", "msi", "nsis", "dmg"],
     "icon": [
       "../icons/32x32.png",
       "../icons/128x128.png",
@@ -40,11 +40,7 @@
     "windows": {
       "certificateThumbprint": null,
       "digestAlgorithm": "sha256",
-      "timestampUrl": "",
-      "msix": {
-        "identityName": "ErichDonahue.SpinnerforDiscogs",
-        "publisherDisplayName": "Erich Donahue"
-      }
+      "timestampUrl": ""
     },
     "macOS": {
       "entitlements": null,

--- a/desktop_shell/src-tauri/tauri.conf.json
+++ b/desktop_shell/src-tauri/tauri.conf.json
@@ -42,8 +42,8 @@
       "digestAlgorithm": "sha256",
       "timestampUrl": "",
       "msix": {
-        "identityName": "EricDonahue.SpinnerforDiscogs",
-        "publisherDisplayName": "Eric Donahue"
+        "identityName": "ErichDonahue.SpinnerforDiscogs",
+        "publisherDisplayName": "Erich Donahue"
       }
     },
     "macOS": {

--- a/docs/STORE_SUBMISSIONS.md
+++ b/docs/STORE_SUBMISSIONS.md
@@ -171,19 +171,19 @@ snapcraft upload spinner-for-discogs_0.2.2_amd64.snap --release=stable
 
 ---
 
-## Channel 5: Microsoft Store (MSIX)
+## Channel 5: Microsoft Store
 
-**Prerequisites:** Microsoft Partner Center account, Publisher Display Name configured in `tauri.conf.json`.
+**Prerequisites:** Microsoft Partner Center account ($19 one-time).
 
-The MSIX artifact is now built automatically by the CI on every tagged release. After
-a tag push completes, the `.msix` file is available in the GitHub Release assets.
+Tauri v2 does not produce MSIX directly. Partner Center accepts the NSIS `.exe` installer
+for Desktop Bridge packaging — no separate MSIX build step needed.
 
-1. Download the `.msix` file from the GitHub Release
+1. Download the `Discogs.Spinner_<VERSION>_x64-setup.exe` from the GitHub Release
 2. Log in to https://partner.microsoft.com/dashboard
 3. Go to **Windows & Xbox** → **Overview** → **Spinner for Discogs**
 4. Click **Start a submission** → **Packages**
-5. Upload the `.msix` file — Partner Center will validate and re-sign it for Store distribution
-6. Fill in: store listing, screenshots, age rating (3+), pricing (free), categories (Music)
+5. Upload the `.exe` — Partner Center wraps it in an MSIX and re-signs it for Store distribution
+6. Fill in: store listing, screenshots (reuse Snap Store screenshots), age rating (3+), pricing (free), category Music
 7. Submit for review (~3-5 business days)
 
 ---
@@ -218,9 +218,9 @@ git push origin main --tags
 #         to manifests/e/ErichDonahue/SpinnerforDiscogs/0.3.0/
 #       - Open PR titled: "Update ErichDonahue.SpinnerforDiscogs to 0.3.0"
 
-#    b. Upload the .msix to Microsoft Partner Center (once account exists)
-#       Download from GitHub Release → Partner Center → Spinner for Discogs
-#       → Start submission → Packages → upload .msix
+#    b. Upload the NSIS .exe to Microsoft Partner Center (once account exists)
+#       Download Discogs.Spinner_X.Y.Z_x64-setup.exe from GitHub Release
+#       → Partner Center → Spinner for Discogs → Start submission → Packages → upload .exe
 
 #    (Snap Store auto-rebuilds from the pushed tag via snap_publish.yml — no manual step)
 ```

--- a/docs/STORE_SUBMISSIONS.md
+++ b/docs/STORE_SUBMISSIONS.md
@@ -44,9 +44,13 @@ Verify with: `spctl --assess --verbose /Applications/DiscogSpinner.app`
 Required for: Microsoft Store (MSIX) submission.
 - Register at https://partner.microsoft.com/dashboard ($19 one-time)
 - Reserve the app name **"Spinner for Discogs"**
-- Note your assigned **Publisher Display Name** and **Publisher ID** (e.g. `CN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`)
-- Update `desktop_shell/src-tauri/tauri.conf.json` → `bundle.windows.msix.publisherDisplayName`
-  to match your registered Publisher Display Name exactly
+- On the app overview → **App identity** page, note:
+  - **Publisher display name** (as registered)
+  - **Package/Identity Name** (e.g. `ErichDonahue.SpinnerforDiscogs` or a GUID-based string)
+- Update `desktop_shell/src-tauri/tauri.conf.json` → `bundle.windows.msix`:
+  - `identityName` → the exact Package/Identity Name from App identity page
+  - `publisherDisplayName` → your registered Publisher Display Name
+- Commit and push — CI will build a fresh MSIX with the correct identity on the next tag
 
 ---
 
@@ -189,15 +193,12 @@ a tag push completes, the `.msix` file is available in the GitHub Release assets
 Run these steps for every new app version (substitute `0.3.0` with the actual version):
 
 ```bash
-# 1. Bump version across pyproject.toml, Cargo.toml, webapp/package.json
+# 1. Bump version across pyproject.toml, Cargo.toml, webapp/package.json, snap/snapcraft.yaml
 ./scripts/bump_version.sh 0.3.0
 
-# 2. Update store manifests that must be committed with the release
-#    a. Snap version
-sed -i 's/^version: ".*"/version: "0.3.0"/' snap/snapcraft.yaml
-
-#    b. AppStream metainfo — add a <release> entry for the new version
-#       Edit packaging/metainfo/com.discogs-spinner.app.metainfo.xml manually
+# 2. AppStream metainfo — add a <release> entry for the new version (~30 sec, manual)
+#    Edit packaging/metainfo/com.discogs-spinner.app.metainfo.xml
+#    Edit packaging/deb/io.github.edonahue.DiscogsSpinner.metainfo.xml
 
 # 3. Write release notes (required by CI to publish the GitHub Release)
 cp docs/releases/TEMPLATE.md docs/releases/v0.3.0.md
@@ -209,24 +210,28 @@ git commit -m "Release 0.3.0"
 git tag v0.3.0
 git push origin main --tags
 
-# 5. After CI completes: generate WinGet manifests (fetches SHA256 automatically)
+# 5. After CI completes
+#    a. Generate WinGet manifests (fetches SHA256 automatically)
 ./scripts/update_winget_manifest.sh 0.3.0
+#       - In your microsoft/winget-pkgs fork, copy:
+#           packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.3.0/
+#         to manifests/e/ErichDonahue/SpinnerforDiscogs/0.3.0/
+#       - Open PR titled: "Update ErichDonahue.SpinnerforDiscogs to 0.3.0"
 
-# 6. Submit WinGet PR
-#    - In your microsoft/winget-pkgs fork, create:
-#        manifests/e/ErichDonahue/SpinnerforDiscogs/0.3.0/
-#    - Copy the 3 YAML files from packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.3.0/
-#    - Open PR titled: "Update ErichDonahue.SpinnerforDiscogs to 0.3.0"
-#    (Snap Store auto-rebuilds from the pushed tag — no extra step needed)
+#    b. Upload the .msix to Microsoft Partner Center (once account exists)
+#       Download from GitHub Release → Partner Center → Spinner for Discogs
+#       → Start submission → Packages → upload .msix
+
+#    (Snap Store auto-rebuilds from the pushed tag via snap_publish.yml — no manual step)
 ```
 
 ### Per-store files to update each release
 
 | Store | File | What changes |
 |---|---|---|
-| All | `pyproject.toml`, `Cargo.toml`, `package.json` | `bump_version.sh` handles this |
-| Snap | `snap/snapcraft.yaml` | `version:` field |
+| All | `pyproject.toml`, `Cargo.toml`, `package.json`, `snap/snapcraft.yaml` | `bump_version.sh` handles this |
 | AppStream | `packaging/metainfo/com.discogs-spinner.app.metainfo.xml` | Add `<release>` entry |
 | WinGet | `packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/<VERSION>/` | `update_winget_manifest.sh` handles this |
+| Microsoft Store | GitHub Release `.msix` → Partner Center upload | Manual (~5 min) |
 | Homebrew | `packaging/homebrew/spinner-for-discogs.rb` | `version`, `sha256` for ARM + Intel |
 | Flatpak | `packaging/flatpak/com.discogs-spinner.app.yml` | `tag:` and `commit:` fields |

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -22,8 +22,9 @@ fi
 PYPROJECT="$REPO_ROOT/pyproject.toml"
 CARGO="$REPO_ROOT/desktop_shell/src-tauri/Cargo.toml"
 PACKAGE_JSON="$REPO_ROOT/webapp/package.json"
+SNAPCRAFT="$REPO_ROOT/snap/snapcraft.yaml"
 
-for f in "$PYPROJECT" "$CARGO" "$PACKAGE_JSON"; do
+for f in "$PYPROJECT" "$CARGO" "$PACKAGE_JSON" "$SNAPCRAFT"; do
     if [[ ! -f "$f" ]]; then
         echo "Error: expected file not found: $f" >&2
         exit 1
@@ -34,12 +35,14 @@ done
 CURRENT_PYPROJECT=$(grep -m1 '^version\s*=' "$PYPROJECT" | sed 's/.*= *"\(.*\)".*/\1/')
 CURRENT_CARGO=$(grep -m1 '^version\s*=' "$CARGO" | sed 's/.*= *"\(.*\)".*/\1/')
 CURRENT_PACKAGE=$(python3 -c "import json, sys; d=json.load(open('$PACKAGE_JSON')); print(d.get('version','?'))")
+CURRENT_SNAPCRAFT=$(grep -m1 '^version:' "$SNAPCRAFT" | sed 's/version: *"\(.*\)".*/\1/')
 
 echo "Bumping version: $NEW_VERSION"
 echo ""
 echo "  pyproject.toml     $CURRENT_PYPROJECT -> $NEW_VERSION"
 echo "  Cargo.toml         $CURRENT_CARGO     -> $NEW_VERSION"
 echo "  package.json       $CURRENT_PACKAGE   -> $NEW_VERSION"
+echo "  snap/snapcraft.yaml $CURRENT_SNAPCRAFT -> $NEW_VERSION"
 echo ""
 
 # pyproject.toml: replace first occurrence of version = "..."
@@ -61,13 +64,17 @@ with open(path, "w") as f:
     f.write("\n")
 EOF
 
-# Verify all three files now report the new version.
+# snap/snapcraft.yaml: replace top-level version: "..."
+sed -i "s/^version: \"[^\"]*\"/version: \"$NEW_VERSION\"/" "$SNAPCRAFT"
+
+# Verify all four files now report the new version.
 VERIFY_PYPROJECT=$(grep -m1 '^version\s*=' "$PYPROJECT" | sed 's/.*= *"\(.*\)".*/\1/')
 VERIFY_CARGO=$(grep -m1 '^version\s*=' "$CARGO" | sed 's/.*= *"\(.*\)".*/\1/')
 VERIFY_PACKAGE=$(python3 -c "import json; print(json.load(open('$PACKAGE_JSON'))['version'])")
+VERIFY_SNAPCRAFT=$(grep -m1 '^version:' "$SNAPCRAFT" | sed 's/version: *"\(.*\)".*/\1/')
 
 FAILED=0
-for pair in "pyproject.toml:$VERIFY_PYPROJECT" "Cargo.toml:$VERIFY_CARGO" "package.json:$VERIFY_PACKAGE"; do
+for pair in "pyproject.toml:$VERIFY_PYPROJECT" "Cargo.toml:$VERIFY_CARGO" "package.json:$VERIFY_PACKAGE" "snap/snapcraft.yaml:$VERIFY_SNAPCRAFT"; do
     name="${pair%%:*}"
     ver="${pair##*:}"
     if [[ "$ver" != "$NEW_VERSION" ]]; then

--- a/tests/test_tauri_installer_contract.py
+++ b/tests/test_tauri_installer_contract.py
@@ -292,7 +292,4 @@ def test_tauri_config_uses_top_level_identifier_only():
     bundle = payload["bundle"]
     assert "identifier" not in bundle
     assert bundle["icon"][0] == "../icons/32x32.png"
-    assert "msix" in bundle["targets"]
-    msix = bundle["windows"]["msix"]
-    assert msix["identityName"]
-    assert msix["publisherDisplayName"]
+    assert "msix" not in bundle["targets"]

--- a/tests/test_tauri_installer_contract.py
+++ b/tests/test_tauri_installer_contract.py
@@ -292,3 +292,7 @@ def test_tauri_config_uses_top_level_identifier_only():
     bundle = payload["bundle"]
     assert "identifier" not in bundle
     assert bundle["icon"][0] == "../icons/32x32.png"
+    assert "msix" in bundle["targets"]
+    msix = bundle["windows"]["msix"]
+    assert msix["identityName"]
+    assert msix["publisherDisplayName"]


### PR DESCRIPTION
## Summary

- Removes `msix` from `bundle.targets` and `bundle.windows` in `tauri.conf.json` — Tauri v2 has no MSIX bundle target; `tauri-cli v2.11.x` rejects it via strict JSON schema validation
- Removes all MSIX references from `installer_build.yml` (build target, artifact upload, stage loop, asset inventory check, publish verification)
- Adds `assert "msix" not in bundle["targets"]` to the installer contract test to prevent re-introduction
- Updates `STORE_SUBMISSIONS.md` Channel 5: Partner Center accepts the NSIS `.exe` directly via Desktop Bridge — no separate MSIX build needed

**Root cause:** The `windows_msi_smoke` scheduled workflow has been failing every day since June 7 with:
```
Error "tauri.conf.json" error on bundle > targets: not valid under any of the schemas
Error "tauri.conf.json" error on bundle > windows: Additional properties not allowed ('msix' was unexpected)
```

**Microsoft Store path is unchanged:** Partner Center wraps the NSIS `.exe` in MSIX and re-signs it internally. The CI already produces and uploads the `.exe` on every tagged release.

Also includes Phase 1 housekeeping from the store distribution plan:
- `bump_version.sh` now updates `snap/snapcraft.yaml` as a 4th target (removes manual sed step from release checklist)
- `STORE_SUBMISSIONS.md` prerequisites section expanded with Partner Center `identityName` update instructions

## Test plan

- [ ] Core Plus CI passes (all 4 jobs)
- [ ] `windows_msi_smoke` scheduled run passes after merge (tomorrow morning ~05:17 UTC)
- [ ] `python -m pytest tests/test_tauri_installer_contract.py` — 11 tests pass

https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_