### PR TITLE
chore: add one-shot workflow to generate and commit Cargo.lock

### DIFF
--- a/.github/workflows/sync_cargo_lock.yml
+++ b/.github/workflows/sync_cargo_lock.yml
@@ -1,0 +1,42 @@
+name: Sync Cargo.lock
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync-cargo-lock:
+    name: Generate and commit Cargo.lock
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: true
+
+      - name: Set up Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate Cargo.lock
+        working-directory: desktop_shell/src-tauri
+        run: cargo generate-lockfile
+
+      - name: Commit Cargo.lock if changed
+        working-directory: desktop_shell/src-tauri
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet Cargo.lock 2>/dev/null && git ls-files --error-unmatch Cargo.lock 2>/dev/null; then
+            echo "Cargo.lock is already up to date — no commit needed."
+          else
+            git add Cargo.lock
+            git commit -m "chore: generate Cargo.lock for deterministic Rust builds"
+            git push origin main
+            echo "Cargo.lock committed and pushed to main."
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync_cargo_lock.yml` — a `workflow_dispatch`-only job that generates `desktop_shell/src-tauri/Cargo.lock` and commits it directly to main
- Requires `contents: write` permission (scoped to this job only)
- Idempotent: if `Cargo.lock` is already up to date, the step prints a message and exits cleanly without creating an empty commit

## Why

The daily `windows_msi_smoke` workflow has hit three distinct dep-resolution failures over the past week (tauri-utils/time conflict, brotli/alloc-no-stdlib diamond) because there is no committed `Cargo.lock`. Every fresh `cargo build` re-solves transitive deps from scratch, so any new incompatible crate release breaks the build.

Once `Cargo.lock` is committed, all builds — CI and local — resolve to exactly the same dep tree. Future dep updates happen explicitly via `cargo update` rather than silently on every build.

## Test plan

- [ ] CI on this PR passes (Core Plus CI)
- [ ] Merge to main
- [ ] Run **Sync Cargo.lock** from Actions → workflow_dispatch → Run workflow
- [ ] Verify a commit appears on main adding `desktop_shell/src-tauri/Cargo.lock`
- [ ] Verify next `windows_msi_smoke` run (05:17 UTC) succeeds

https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_