### PR TITLE
fix: use tauri-plugin-shell = "2" (latest 2.x is 2.3.5, not 2.11)

### DIFF
--- a/.github/workflows/sync_cargo_lock.yml
+++ b/.github/workflows/sync_cargo_lock.yml
@@ -1,0 +1,42 @@
+name: Sync Cargo.lock
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync-cargo-lock:
+    name: Generate and commit Cargo.lock
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: true
+
+      - name: Set up Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate Cargo.lock
+        working-directory: desktop_shell/src-tauri
+        run: cargo generate-lockfile
+
+      - name: Commit Cargo.lock if changed
+        working-directory: desktop_shell/src-tauri
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet Cargo.lock 2>/dev/null && git ls-files --error-unmatch Cargo.lock 2>/dev/null; then
+            echo "Cargo.lock is already up to date — no commit needed."
+          else
+            git add Cargo.lock
+            git commit -m "chore: generate Cargo.lock for deterministic Rust builds"
+            git push origin main
+            echo "Cargo.lock committed and pushed to main."
+          fi

--- a/desktop_shell/src-tauri/Cargo.toml
+++ b/desktop_shell/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ tauri-build = { version = "2.11", features = [] }
 
 [dependencies]
 tauri = { version = "2.11", features = [] }
-tauri-plugin-shell = "2.11"
+tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = "2"


### PR DESCRIPTION
## Summary

- Fixes `tauri-plugin-shell` version in `desktop_shell/src-tauri/Cargo.toml` from `"2.11"` → `"2"`

## Why

`tauri-plugin-shell` has its own versioning that tops out at `2.3.5` — it does not track the same `2.11` series as the `tauri` and `tauri-build` crates. Pinning it to `"2.11"` caused `cargo generate-lockfile` to fail with:

```
error: failed to select a version for the requirement `tauri-plugin-shell = "^2.11"`
candidate versions found which didn't match: 2.3.5, 2.3.4, 2.3.3, ...
```

This broke the new **Sync Cargo.lock** workflow immediately on first run. Using `"2"` resolves to `2.3.5` (the latest stable 2.x release).

## Test plan

- [ ] CI passes
- [ ] Merge to main
- [ ] Re-run **Sync Cargo.lock** from Actions → workflow_dispatch
- [ ] Verify `Cargo.lock` commit appears on main

https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_