### PR TITLE
fix: use tauri-build = \"2\" (latest 2.x is 2.6.2, not 2.11)

### DIFF
--- a/.github/workflows/sync_cargo_lock.yml
+++ b/.github/workflows/sync_cargo_lock.yml
@@ -1,0 +1,42 @@
+name: Sync Cargo.lock
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  sync-cargo-lock:
+    name: Generate and commit Cargo.lock
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: true
+
+      - name: Set up Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate Cargo.lock
+        working-directory: desktop_shell/src-tauri
+        run: cargo generate-lockfile
+
+      - name: Commit Cargo.lock if changed
+        working-directory: desktop_shell/src-tauri
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet Cargo.lock 2>/dev/null && git ls-files --error-unmatch Cargo.lock 2>/dev/null; then
+            echo "Cargo.lock is already up to date — no commit needed."
+          else
+            git add Cargo.lock
+            git commit -m "chore: generate Cargo.lock for deterministic Rust builds"
+            git push origin main
+            echo "Cargo.lock committed and pushed to main."
+          fi

--- a/desktop_shell/src-tauri/Cargo.toml
+++ b/desktop_shell/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ tauri-build = { version = "2.11", features = [] }
 
 [dependencies]
 tauri = { version = "2.11", features = [] }
-tauri-plugin-shell = "2.11"
+tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = "2"

--- a/desktop_shell/src-tauri/Cargo.toml
+++ b/desktop_shell/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ name = "discogs_spinner_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.11", features = [] }
+tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2.11", features = [] }


### PR DESCRIPTION
## Summary

- Changes `tauri-build` version in `desktop_shell/src-tauri/Cargo.toml` from `"2.11"` → `"2"`

## Why

`tauri-build` has its own versioning that tops out at `2.6.2` — it does not track the same `2.11` series as the core `tauri` crate. The second run of **Sync Cargo.lock** hit:

```
error: failed to select a version for the requirement `tauri-build = "^2.11"`
candidate versions found which didn't match: 2.6.2, 2.6.1, 2.6.0, ...
```

Keeping `tauri = "2.11"` is sufficient to pin `tauri-utils 2.11.x` transitively and prevent the time/tauri-utils conflict — `tauri-build`'s version is independent of that.

**Cargo.toml after this PR:**
```toml
tauri-build = { version = "2", features = [] }   # resolves to 2.6.2
tauri = { version = "2.11", features = [] }       # pins tauri-utils 2.11.x
tauri-plugin-shell = "2"                          # resolves to 2.3.5
```

## Test plan

- [ ] CI passes
- [ ] Merge to main
- [ ] Re-run **Sync Cargo.lock** — should succeed and commit `Cargo.lock`

https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrKJ49RkgSGhCkqxcQ56Bn)_