### PR TITLE
Fix Cargo.lock brotli dependency conflict (installer build fix)

### DIFF
--- a/desktop_shell/src-tauri/Cargo.lock
+++ b/desktop_shell/src-tauri/Cargo.lock
@@ -24,18 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fb6cfd47bf496ff64095c20eaba0c201404ee38714d4142fcfa1dc334fcc7a"
-
-[[package]]
 name = "alloc-stdlib"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982052a20ce6eccdc3ee95f1fd77f10bf6b7ff5b02c3c4cc5a3fb50ce506a108"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
- "alloc-no-stdlib 3.0.0",
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -159,22 +153,22 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
- "alloc-no-stdlib 2.0.4",
+ "alloc-no-stdlib",
  "alloc-stdlib",
  "brotli-decompressor",
 ]
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.2"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bebb348517c190d59e80c4f19c2beef71cf89d9df0c46386be8f92c7021fec"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
- "alloc-no-stdlib 3.0.0",
+ "alloc-no-stdlib",
  "alloc-stdlib",
 ]
 


### PR DESCRIPTION
## Summary

- Fixes all Tauri installer builds (Windows, macOS, Linux) that were failing with a brotli/alloc-no-stdlib type conflict
- `cargo update` bumps `brotli` 8.0.3 → 8.0.4 and `brotli-decompressor` 5.0.2 → 5.0.3, removing the duplicate `alloc-no-stdlib` 3.0.0 so only the consistent 2.0.4 version remains

**Root cause**: When `tauri-plugin-updater` was added, `cargo check` updated the Cargo.lock before failing on missing system GTK headers, leaving brotli 8.0.3 (which uses alloc-no-stdlib 2.0.4) paired with brotli-decompressor 5.0.2 (which uses alloc-no-stdlib 3.0.0). These two versions of the same trait are incompatible, breaking all `cargo tauri build` invocations.

## Test plan
- [ ] Tauri installer builds (Windows, macOS, Linux) pass

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_