### PR TITLE
Fix MSIX staging: correct binary name and include API sidecar

### DIFF
--- a/.github/workflows/installer_build.yml
+++ b/.github/workflows/installer_build.yml
@@ -329,10 +329,26 @@ jobs:
           $stageDir = "dist/windows-app-stage"
           New-Item -Force -ItemType Directory $stageDir | Out-Null
 
-          $appExe = Join-Path $relDir "Discogs Spinner.exe"
-          if (-not (Test-Path $appExe)) { Write-Error "Main app binary not found: $appExe"; exit 1 }
-          Copy-Item $appExe $stageDir
-          Write-Host "Staged: Discogs Spinner.exe"
+          # Cargo names the binary after the package ("discogs-spinner.exe");
+          # the manifest expects the productName ("Discogs Spinner.exe"), so rename.
+          $cargoExe = Join-Path $relDir "discogs-spinner.exe"
+          if (-not (Test-Path $cargoExe)) {
+            Write-Host "EXEs in release dir:"
+            Get-ChildItem $relDir -Filter "*.exe" -File | Select-Object Name
+            Write-Error "Main app binary not found: $cargoExe"; exit 1
+          }
+          Copy-Item $cargoExe (Join-Path $stageDir "Discogs Spinner.exe")
+          Write-Host "Staged: discogs-spinner.exe -> Discogs Spinner.exe"
+
+          # Sidecar: strip the target-triple suffix that Tauri adds to source binaries.
+          # At runtime the app looks for "dplayer-api.exe" in its own directory.
+          $sidecarSrc = "desktop_shell/src-tauri/binaries/dplayer-api-${{ matrix.target_triple }}.exe"
+          if (Test-Path $sidecarSrc) {
+            Copy-Item $sidecarSrc (Join-Path $stageDir "dplayer-api.exe")
+            Write-Host "Staged: dplayer-api.exe (sidecar)"
+          } else {
+            Write-Error "Sidecar not found: $sidecarSrc"; exit 1
+          }
 
           Get-ChildItem $relDir -Filter "*.dll" -File | ForEach-Object {
             Copy-Item $_.FullName $stageDir


### PR DESCRIPTION
## Problems

The Windows `build-tauri` staging step had two bugs that caused MSIX to either fail or produce a broken package:

**1. Wrong binary name**
Cargo names the output binary after the package (`discogs-spinner.exe`), but `Package.appxmanifest` declares `Executable="Discogs Spinner.exe"` (the product name). The staging step was looking for `Discogs Spinner.exe` directly, which doesn't exist in `target/release/`, so it errored immediately.

**2. Missing API sidecar (caught by Codex review)**
The staging step never copied `dplayer-api.exe`. The app calls `app.shell().sidecar("dplayer-api")` on startup — without it, any MSIX install would fail to start the local API.

## Fix

- Copy `discogs-spinner.exe` → `Discogs Spinner.exe` (rename to match manifest)
- Copy `dplayer-api-x86_64-pc-windows-msvc.exe` → `dplayer-api.exe` (strip Tauri's target-triple suffix, which is how the app resolves it at runtime)
- Added diagnostic listing of `.exe` files if the main binary is missing (helps future debugging)

## Test plan

- [ ] `build-tauri (windows-2022)` staging step finds `discogs-spinner.exe` and uploads `windows-app-stage` with `Discogs Spinner.exe` + `dplayer-api.exe`
- [ ] `build-msix` completes and produces a `.msix` artifact
- [ ] `publish-release` finds and uploads the `.msix`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_