### PR TITLE
Fix MSIX manifest: valid Identity placeholder until Partner Center app reserved

### DIFF
--- a/.github/workflows/installer_build.yml
+++ b/.github/workflows/installer_build.yml
@@ -403,7 +403,7 @@ jobs:
 
           # Update manifest version to match app version (x.y.z.0 format)
           $manifest = Get-Content packaging/msix/Package.appxmanifest -Raw
-          $manifest = $manifest -replace 'Version="[^"]*"', "Version=`"$env:APP_VERSION.0`""
+          $manifest = $manifest -creplace 'Version="[^"]*"', "Version=`"$env:APP_VERSION.0`""
           $manifest | Set-Content "$pkgDir\AppxManifest.xml"
 
           # Copy tile assets

--- a/.github/workflows/installer_build.yml
+++ b/.github/workflows/installer_build.yml
@@ -329,10 +329,26 @@ jobs:
           $stageDir = "dist/windows-app-stage"
           New-Item -Force -ItemType Directory $stageDir | Out-Null
 
-          $appExe = Join-Path $relDir "Discogs Spinner.exe"
-          if (-not (Test-Path $appExe)) { Write-Error "Main app binary not found: $appExe"; exit 1 }
-          Copy-Item $appExe $stageDir
-          Write-Host "Staged: Discogs Spinner.exe"
+          # Cargo names the binary after the package ("discogs-spinner.exe");
+          # the manifest expects the productName ("Discogs Spinner.exe"), so rename.
+          $cargoExe = Join-Path $relDir "discogs-spinner.exe"
+          if (-not (Test-Path $cargoExe)) {
+            Write-Host "EXEs in release dir:"
+            Get-ChildItem $relDir -Filter "*.exe" -File | Select-Object Name
+            Write-Error "Main app binary not found: $cargoExe"; exit 1
+          }
+          Copy-Item $cargoExe (Join-Path $stageDir "Discogs Spinner.exe")
+          Write-Host "Staged: discogs-spinner.exe -> Discogs Spinner.exe"
+
+          # Sidecar: strip the target-triple suffix that Tauri adds to source binaries.
+          # At runtime the app looks for "dplayer-api.exe" in its own directory.
+          $sidecarSrc = "desktop_shell/src-tauri/binaries/dplayer-api-${{ matrix.target_triple }}.exe"
+          if (Test-Path $sidecarSrc) {
+            Copy-Item $sidecarSrc (Join-Path $stageDir "dplayer-api.exe")
+            Write-Host "Staged: dplayer-api.exe (sidecar)"
+          } else {
+            Write-Error "Sidecar not found: $sidecarSrc"; exit 1
+          }
 
           Get-ChildItem $relDir -Filter "*.dll" -File | ForEach-Object {
             Copy-Item $_.FullName $stageDir

--- a/packaging/msix/Package.appxmanifest
+++ b/packaging/msix/Package.appxmanifest
@@ -2,13 +2,17 @@
 <!--
   MSIX Package Manifest for Discogs Spinner
   ==========================================
-  Before submitting to the Microsoft Store, replace the PLACEHOLDER values:
+  Before submitting to the Microsoft Store, update the Identity and Publisher
+  values below with the ones assigned by Partner Center:
 
   1. Identity/@Name        — assigned by Partner Center during app reservation
-                             e.g. "ErichDonahue.SpinnerforDiscogs"
   2. Identity/@Publisher   — your Partner Center Publisher CN string
                              e.g. "CN=Erich Donahue, O=Erich Donahue, L=Portland, S=Oregon, C=US"
   3. Properties/PublisherDisplayName — your display name as entered in Partner Center
+
+  The current values are syntactically valid stand-ins so CI can build and
+  test the packaging pipeline before the app is reserved in Partner Center.
+  Replace them once you have your real Partner Center Identity/Name and Publisher CN.
 
   The Microsoft Store signs the MSIX at submission time; no Windows EV cert is
   required when distributing exclusively through the Store.
@@ -24,8 +28,8 @@
   IgnorableNamespaces="mp uap uap3 rescap">
 
   <Identity
-    Name="PLACEHOLDER_PARTNER_CENTER_PACKAGE_NAME"
-    Publisher="PLACEHOLDER_PARTNER_CENTER_PUBLISHER_CN"
+    Name="ErichDonahue.SpinnerforDiscogs"
+    Publisher="CN=ErichDonahue"
     Version="0.2.2.0"
     ProcessorArchitecture="x64" />
 
@@ -35,7 +39,7 @@
 
   <Properties>
     <DisplayName>Spinner for Discogs</DisplayName>
-    <PublisherDisplayName>PLACEHOLDER_PUBLISHER_DISPLAY_NAME</PublisherDisplayName>
+    <PublisherDisplayName>Erich Donahue</PublisherDisplayName>
     <Logo>assets\StoreLogo.png</Logo>
   </Properties>
 


### PR DESCRIPTION
## Problem

`makeappx.exe` rejects `PLACEHOLDER_PARTNER_CENTER_PACKAGE_NAME` because `Identity/@Name` must match the pattern `[-.A-Za-z0-9]+` (underscores not allowed). The `/nv` flag skips security validation but not schema validation.

## Fix

Replace the underscore-based placeholders with syntactically valid stand-in values:
- `Name="ErichDonahue.SpinnerforDiscogs"` — the likely real Partner Center name once the app is reserved  
- `Publisher="CN=ErichDonahue"` — minimal valid CN format
- `PublisherDisplayName="Erich Donahue"`

These let CI build and test the full MSIX pipeline now. Once the app is reserved in Partner Center, the exact Name and full Publisher CN should be updated in the manifest.

## After Partner Center app reservation

Update `packaging/msix/Package.appxmanifest`:
1. `Identity/@Name` → the name assigned by Partner Center (e.g. `ErichDonahue.SpinnerforDiscogs`)
2. `Identity/@Publisher` → your full CN string from Partner Center (e.g. `CN=Erich Donahue, O=Erich Donahue, L=Portland, S=Oregon, C=US`)
3. `Properties/PublisherDisplayName` → your display name as shown in Partner Center

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_