### PR TITLE
chore(store): unblock Flathub metadata, deps helper, readiness snapshot

### DIFF
--- a/docs/STORE_SUBMISSIONS.md
+++ b/docs/STORE_SUBMISSIONS.md
@@ -5,6 +5,24 @@ channel. Complete steps in the order shown — later channels depend on earlier 
 
 ---
 
+## Submission Readiness Snapshot
+
+At-a-glance status of every channel and the single next blocker for the ones that
+are not yet live. Full per-channel steps follow below.
+
+| Channel | Status | Next blocker / action |
+|---|---|---|
+| WinGet | ✅ Live | Per-release: `./scripts/update_winget_manifest.sh <version>` then PR |
+| Snap Store | ✅ Live | Auto-publishes on `v*` tag via `snap_publish.yml` |
+| Homebrew Cask | 🟡 Ready, blocked on macOS notarization | Notarize the `.dmg` (needs Apple Developer Program), then submit the PR — formula SHA256s for 0.2.2 are already filled in |
+| Flathub | 🟡 Ready, needs deps JSON | Run `./scripts/gen_flatpak_deps.sh`, set the real commit SHA in the manifest, then submit the PR — screenshots in the metainfo are already populated |
+| Microsoft Store | 🟡 Ready, blocked on Partner Center | Register Partner Center ($19), replace the `TODO(partner-center)` Identity/Publisher in `packaging/msix/Package.appxmanifest`, convert the NSIS `.exe` to MSIX, upload |
+
+Items marked 🟡 require an external account, paid program, or a clean OS — the in-repo
+prep for each is done; the remaining work is the manual submission step.
+
+---
+
 ## Naming Convention
 
 All **store display names** use **"Spinner for Discogs"** to comply with Discogs LLC
@@ -55,7 +73,8 @@ Required for: Microsoft Store submission.
 **File:** `packaging/homebrew/spinner-for-discogs.rb`
 
 1. Download the notarized `.dmg` files for both architectures from the GitHub Release
-2. Compute SHA256 checksums and replace the `PLACEHOLDER_SHA256_*` values in the formula
+2. Confirm the `sha256` values in the formula match the released `.dmg` files (already
+   filled in for 0.2.2; recompute with `shasum -a 256 <file>.dmg` for new releases)
 3. Fork https://github.com/Homebrew/homebrew-cask
 4. Copy the formula to `Casks/s/spinner-for-discogs.rb`
 5. Run locally: `brew install --cask ./Casks/s/spinner-for-discogs.rb`
@@ -104,16 +123,16 @@ For manual submission:
 
 2. Generate Python dependency sources (re-run whenever `pyproject.toml` deps change):
    ```bash
-   flatpak-pip-generator --runtime org.gnome.Sdk//48 \
-     httpx uvicorn fastapi starlette anyio h11 httpcore \
-     typer rich python-dotenv ytmusicapi platformdirs \
-     keyring rapidfuzz certifi idna sniffio \
-     > packaging/flatpak/python3-deps.json
+   ./scripts/gen_flatpak_deps.sh
    ```
-   Then uncomment the `- python3-deps.json` line in the Flatpak manifest.
+   This wraps `flatpak-pip-generator` with the exact runtime dependency set and writes
+   `packaging/flatpak/python3-deps.json`. Then uncomment the `- python3-deps.json` line
+   in the Flatpak manifest.
 
-3. Add screenshots to `packaging/metainfo/` and uncomment the `<screenshots>` block
-   in `packaging/metainfo/com.discogs-spinner.app.metainfo.xml`
+3. Screenshots: the `<screenshots>` block in
+   `packaging/metainfo/com.discogs-spinner.app.metainfo.xml` is already populated with the
+   five `docs/media/screenshots/*.png` images. Confirm they meet Flathub's size guidance
+   (1248×702 or 624×351) and refresh them if the UI has changed.
 
 4. Validate the metainfo:
    ```bash

--- a/packaging/metainfo/com.discogs-spinner.app.metainfo.xml
+++ b/packaging/metainfo/com.discogs-spinner.app.metainfo.xml
@@ -50,17 +50,26 @@
   <url type="vcs-browser">https://github.com/edonahue/Discogs_Spinner</url>
 
   <screenshots>
-    <!--
-      BEFORE SUBMITTING TO FLATHUB: Replace these placeholder entries with real
-      screenshots of the app. Recommended size: 1248x702 or 624x351.
-      At least one screenshot is required for Flathub review.
-
-      Example:
-      <screenshot type="default">
-        <caption>Collection gallery showing vinyl records</caption>
-        <image>https://raw.githubusercontent.com/edonahue/Discogs_Spinner/main/docs/screenshots/gallery.png</image>
-      </screenshot>
-    -->
+    <screenshot type="default">
+      <caption>Browse your synced record collection as a cover-art gallery</caption>
+      <image>https://raw.githubusercontent.com/edonahue/Discogs_Spinner/main/docs/media/screenshots/01-browse-gallery.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Spin a random record and inspect its details</caption>
+      <image>https://raw.githubusercontent.com/edonahue/Discogs_Spinner/main/docs/media/screenshots/02-spin-result.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Track market value across your collection</caption>
+      <image>https://raw.githubusercontent.com/edonahue/Discogs_Spinner/main/docs/media/screenshots/03-market-value-dashboard.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Keep wantlist context close while you browse</caption>
+      <image>https://raw.githubusercontent.com/edonahue/Discogs_Spinner/main/docs/media/screenshots/04-wantlist-view.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Quick first-run setup: paste a Discogs token and sync</caption>
+      <image>https://raw.githubusercontent.com/edonahue/Discogs_Spinner/main/docs/media/screenshots/05-setup-wizard.png</image>
+    </screenshot>
   </screenshots>
 
   <releases>

--- a/packaging/msix/Package.appxmanifest
+++ b/packaging/msix/Package.appxmanifest
@@ -31,6 +31,9 @@
     Publisher="CN=ErichDonahue"
     Version="0.2.2.0"
     ProcessorArchitecture="x64" />
+  <!-- TODO(partner-center): replace Identity/@Name and Identity/@Publisher above with the
+       values assigned during app reservation, and PublisherDisplayName below if it differs.
+       See docs/STORE_SUBMISSIONS.md → "Channel 5: Microsoft Store". -->
 
   <mp:PhoneIdentity
     PhoneProductId="00000000-0000-0000-0000-000000000000"

--- a/scripts/gen_flatpak_deps.sh
+++ b/scripts/gen_flatpak_deps.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# gen_flatpak_deps.sh — generate the bundled Python dependency sources for the
+# Flathub build (python3-deps.json) using flatpak-pip-generator.
+#
+# Usage: ./scripts/gen_flatpak_deps.sh
+#
+# Requires: python3 + pip, and flatpak-pip-generator on PATH
+#   pip install flatpak-pip-generator
+#
+# What it does:
+#   1. Runs flatpak-pip-generator against the GNOME SDK runtime with the exact
+#      runtime dependency set Spinner for Discogs needs at execution time.
+#   2. Writes python3-deps.json next to the Flatpak manifest.
+#   3. Reminds you to uncomment the "- python3-deps.json" include in the manifest
+#      and to commit the generated file alongside it.
+#
+# Keep the dependency list below in sync with the runtime deps in pyproject.toml.
+# (Build-only / dev / test extras are intentionally excluded — Flathub builds the
+# app, it does not run the test suite.)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST_DIR="$REPO_ROOT/packaging/flatpak"
+OUTPUT="$MANIFEST_DIR/python3-deps.json"
+
+# GNOME SDK version must match runtime-version in the Flatpak manifest.
+GNOME_SDK="org.gnome.Sdk//48"
+
+# Runtime dependencies (core + optional Spotify/YouTube Music integrations).
+DEPS=(
+    httpx
+    uvicorn
+    fastapi
+    starlette
+    anyio
+    h11
+    httpcore
+    typer
+    rich
+    python-dotenv
+    ytmusicapi
+    platformdirs
+    keyring
+    rapidfuzz
+    certifi
+    idna
+    sniffio
+)
+
+if ! command -v flatpak-pip-generator >/dev/null 2>&1; then
+    echo "error: flatpak-pip-generator not found on PATH." >&2
+    echo "       Install it with: pip install flatpak-pip-generator" >&2
+    exit 1
+fi
+
+echo "Generating Flatpak Python deps with runtime $GNOME_SDK ..."
+flatpak-pip-generator --runtime "$GNOME_SDK" "${DEPS[@]}" --output "${OUTPUT%.json}"
+
+echo
+echo "Wrote: $OUTPUT"
+echo
+echo "Next steps:"
+echo "  1. Uncomment '- python3-deps.json' under 'modules:' in"
+echo "     packaging/flatpak/com.discogs-spinner.app.yml"
+echo "  2. Commit python3-deps.json alongside the manifest."
+echo "  3. See docs/flathub_submission_checklist.md for the remaining steps."


### PR DESCRIPTION
## Summary

Store-distribution readiness prep (PR 1 of 3 from a repo review). Docs + packaging metadata only — **no application-code behavior changes**.

This consolidates the per-store work into the existing canonical `docs/STORE_SUBMISSIONS.md` rather than fragmenting into three new checklist files (the doc already has thorough per-channel sections).

### S1 — Unblock Flathub
- Replaced the placeholder comment in the AppStream `<screenshots>` block (`packaging/metainfo/com.discogs-spinner.app.metainfo.xml`) with the five existing `docs/media/screenshots/*.png` images, captioned. This was a hard Flathub-review blocker.
- Added `scripts/gen_flatpak_deps.sh` — a thin wrapper around `flatpak-pip-generator` (house-style, matching `update_winget_manifest.sh`) that emits `python3-deps.json` from the exact runtime dependency set.

### S2 — Homebrew
- The formula (`packaging/homebrew/spinner-for-discogs.rb`) already carries real 0.2.2 SHA256s; corrected the stale `STORE_SUBMISSIONS.md` step that told you to "replace `PLACEHOLDER_SHA256_*`". Remaining blocker is macOS notarization (external).

### S3 — Microsoft Store / MSIX
- Added greppable `TODO(partner-center)` markers on the `Identity/@Name` and `@Publisher` placeholders in `packaging/msix/Package.appxmanifest`.

### Docs
- Added a **Submission Readiness Snapshot** table at the top of `STORE_SUBMISSIONS.md` showing every channel's status and its single next blocker.

## Test plan
- [x] `packaging/metainfo/com.discogs-spinner.app.metainfo.xml` parses as valid XML
- [x] `packaging/msix/Package.appxmanifest` parses as valid XML
- [x] `bash -n scripts/gen_flatpak_deps.sh` passes
- [x] Confirmed the 5 screenshots exist (1440×900, within Flathub limits)

## Note on scope
Screenshots are 1440×900 (16:10) rather than the AppStream sample 1248×702 — within Flathub's size limits, flagged in the docs so they can be re-captured if desired. The `commit:` SHA in the flatpak manifest and the generated `python3-deps.json` are intentionally left for submission time (the commit must point at a real release tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_