### PR TITLE
ci: gate main on the full test suite; hygiene fixes

### DIFF
--- a/.github/workflows/core_plus_ci.yml
+++ b/.github/workflows/core_plus_ci.yml
@@ -85,6 +85,34 @@ jobs:
       - name: Compile check
         run: python -m compileall -q src tests
 
+  test-full:
+    name: Test Full Suite
+    needs:
+      - prepublish-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install full profile
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev,spotify]"
+
+      - name: Run full test suite
+        # The complete suite (vs. the curated fast subset above). GTK widget
+        # unit tests stub PyGObject, so no system GTK is needed here; the two
+        # GUI smoke-script tests detect the absent GTK runtime and skip.
+        run: python -m pytest -q tests/
+
+      - name: Compile check
+        run: python -m compileall -q src tests
+
   build-artifacts:
     name: Build Artifacts (${{ matrix.os }})
     needs:

--- a/src/discogs_player/ui/dialogs/preferences_window.py
+++ b/src/discogs_player/ui/dialogs/preferences_window.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
+import logging
 
 import gi
 
@@ -14,12 +15,14 @@ from discogs_player.capabilities import get_capabilities
 from discogs_player.core.settings import get_discogs_token
 from discogs_player.use_cases.config_management import run_config_set, run_config_unset
 
+logger = logging.getLogger(__name__)
+
 
 def _open_uri(uri: str) -> None:
     try:
         Gio.AppInfo.launch_default_for_uri(uri, None)
     except Exception:
-        pass
+        logger.warning("Could not open URI in default handler: %s", uri, exc_info=True)
 
 
 class PreferencesWindow(Adw.PreferencesWindow):

--- a/src/discogs_player/ui/dialogs/setup_wizard.py
+++ b/src/discogs_player/ui/dialogs/setup_wizard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
+import logging
 import threading
 import time
 
@@ -19,12 +20,14 @@ from discogs_player.use_cases.config_management import run_config_set
 from discogs_player.use_cases.setup_report import run_setup_report
 from discogs_player.use_cases.sync_collection import SyncCancelledError, run_sync_collection
 
+logger = logging.getLogger(__name__)
+
 
 def _open_uri(uri: str) -> None:
     try:
         Gio.AppInfo.launch_default_for_uri(uri, None)
     except Exception:
-        pass
+        logger.warning("Could not open URI in default handler: %s", uri, exc_info=True)
 
 
 def _make_heading(text: str) -> Gtk.Label:

--- a/src/discogs_player/ui/widgets/album_detail.py
+++ b/src/discogs_player/ui/widgets/album_detail.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import urllib.parse
 from collections.abc import Callable
 
@@ -9,6 +10,8 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, Pango
+
+logger = logging.getLogger(__name__)
 
 
 from discogs_player.ui.utils.formatting import (
@@ -38,6 +41,7 @@ def _make_youtube_icon() -> Gtk.Image:
         loader.close()
         return Gtk.Image.new_from_pixbuf(loader.get_pixbuf())
     except Exception:
+        logger.debug("Could not render YouTube icon SVG; using blank image", exc_info=True)
         return Gtk.Image()
 
 

--- a/src/discogs_player/ui_main.py
+++ b/src/discogs_player/ui_main.py
@@ -82,8 +82,11 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     try:
         import gi
-    except ModuleNotFoundError as exc:
-        module_name = exc.name or "gi"
+    except ImportError as exc:
+        # ModuleNotFoundError (gi absent) or a broken PyGObject install (e.g. a
+        # half-built _gi extension) both land here; show the install guidance
+        # instead of letting a raw traceback escape.
+        module_name = getattr(exc, "name", None) or "gi"
         print(_missing_gui_dependency_message(module_name), file=sys.stderr)
         return 1
 

--- a/tests/test_gallery_ux_smoke_script.py
+++ b/tests/test_gallery_ux_smoke_script.py
@@ -33,6 +33,11 @@ def test_gallery_ux_smoke_script_emits_valid_json_when_gui_runtime_is_available(
             "Missing dependency: xvfb-run" in stderr
             or "Missing GUI dependency:" in stderr
             or "Gtk couldn't be initialized" in stderr
+            # No GTK runtime at all (no python3-gi) or a broken PyGObject build —
+            # nothing to smoke-test, so skip rather than fail.
+            or "No module named 'gi'" in stderr
+            or "cannot import name '_gi'" in stderr
+            or "Namespace Gtk not available" in stderr
         ):
             pytest.skip("GUI runtime dependencies unavailable for smoke execution")
         pytest.fail(

--- a/tests/test_gui_smoke_script.py
+++ b/tests/test_gui_smoke_script.py
@@ -33,6 +33,11 @@ def test_gui_smoke_script_emits_valid_json_when_gui_runtime_is_available():
             "Missing GUI dependency:" in stderr
             or "Missing dependency: xvfb-run" in stderr
             or "Gtk couldn't be initialized" in stderr
+            # No GTK runtime at all (no python3-gi) or a broken PyGObject build —
+            # nothing to smoke-test, so skip rather than fail.
+            or "No module named 'gi'" in stderr
+            or "cannot import name '_gi'" in stderr
+            or "Namespace Gtk not available" in stderr
         ):
             pytest.skip("GUI runtime dependencies unavailable for smoke execution")
         pytest.fail(f"gui smoke script failed: rc={completed.returncode}\n{stderr}")

--- a/tests/test_tauri_installer_contract.py
+++ b/tests/test_tauri_installer_contract.py
@@ -243,7 +243,7 @@ def test_installer_workflow_runs_sidecar_and_platform_bundle_validators():
         "Checkout",
         "uses: actions/checkout@v4",
         "Validate release notes file",
-        'test -f "$RELEASE_NOTES_PATH"',
+        'if [[ ! -f "$RELEASE_NOTES_PATH" ]]; then',
         "Create or update GitHub Release metadata",
         'gh release edit "$RELEASE_TAG"',
         'gh release create "$RELEASE_TAG"',


### PR DESCRIPTION
## Summary

PR 2 of 3 from a repo review. Closes the biggest quiet quality gap: **CI ran only ~7 of 84 test files**, so the 682-test suite never gated `main`.

### Q1 — Full test suite in CI
- New `test-full` job in `core_plus_ci.yml` runs the whole `pytest tests/` (`.[dev,spotify]`), in parallel with the existing curated fast jobs (kept for quick PR feedback). The full job is the completeness gate.
- Turning the suite on immediately caught a **latent stale test**: `test_tauri_installer_contract.py` asserted the installer workflow contained `test -f "$RELEASE_NOTES_PATH"`, but commit #22 changed that to `if [[ ! -f "$RELEASE_NOTES_PATH" ]]; then` (warn + placeholder for test tags). Updated the marker to match the real workflow — exactly the kind of drift the gate exists to catch.
- Made the two GUI smoke-script tests (`test_gui_smoke_script`, `test_gallery_ux_smoke_script`) **skip cleanly** when no GTK runtime is importable (no `python3-gi`, or a broken PyGObject build). They already skipped for partial deps; the detection just missed the no-`gi` case. They still execute on machines that have GTK.

### Q4 — Hygiene
- Replaced silent `except Exception: pass` swallows on the URI-open helpers (`setup_wizard.py`, `preferences_window.py`) with logged warnings, and log the `album_detail` icon-render fallback at debug level.
- Broadened the `import gi` guard in `ui_main.py` from `ModuleNotFoundError` to `ImportError`, so a broken PyGObject install now prints the install guidance instead of leaking a raw traceback (verified locally).

## Note on scope
The other two Q4 items from the original plan turned out to be **already done**: `webapp/dist/` is untracked and already in `.gitignore` (line 67), and the stray root debug scripts (`reproduce_carousel_spin.py`, etc.) are not in the tree.

## Test plan
- [x] `python -m pytest -q tests/` → **677 passed, 6 skipped** locally (the 6 skips = 4 pre-existing + 2 GUI smoke tests with no GTK runtime)
- [x] `core_plus_ci.yml` parses as valid YAML
- [x] Modified modules compile (`compileall`)
- [x] Verified `ui_main` prints the friendly missing-dependency message (rc=1) on a broken `gi`, instead of a traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_