### PR TITLE
ftux: report-a-problem link, consistent setup errors, snap schema precompile

### DIFF
--- a/docs/STORE_SUBMISSIONS.md
+++ b/docs/STORE_SUBMISSIONS.md
@@ -156,6 +156,14 @@ Flathub review typically takes 1-4 weeks.
   messages, a COSMIC dconf profile fallback, and missing IM/media module
   warnings. Treat these as polish debt unless a user-visible launch failure
   appears.
+- **Schema warnings mitigation (needs verification):** `snap/snapcraft.yaml` now
+  precompiles the staged GSettings schemas at prime time
+  (`glib-compile-schemas` in `override-prime`), which should remove the repeated
+  GLib schema symlink/compile messages. This has not yet been verified against a
+  real snap rebuild — confirm on the next build with
+  `snap run spinner-for-discogs` and check that the schema warnings are gone. The
+  remaining libproxy / COSMIC dconf / IM-module messages originate in the host
+  desktop environment and are not fixable from the package.
 
 ### Listing metadata
 
@@ -260,7 +268,8 @@ snapcraft upload spinner-for-discogs_0.2.2_amd64.snap --release=stable
 - Tune the first-time user experience so a fresh snap launch immediately explains
   the Discogs token requirement and next step.
 - Reduce harmless terminal warning noise from GTK/GIO/libproxy/schema setup where
-  practical.
+  practical. (GSettings schema precompile is now wired in `snapcraft.yaml`; verify
+  it on the next snap build and tackle any residual GTK/GIO noise from there.)
 - Add a featured banner sized for Snapcraft once the visual direction is stable.
 - Add a short hosted demo video after the first-run flow is polished.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,9 @@ parts:
     source: .
     python-packages:
       - ".[web,spotify]"
+    build-packages:
+      # Provides glib-compile-schemas for the schema precompile step below.
+      - libglib2.0-bin
     stage-packages:
       - python3-gi
       - python3-gi-cairo
@@ -68,6 +71,17 @@ parts:
       - libgtk-4-1
       - libglib2.0-0
       - adwaita-icon-theme
+    override-prime: |
+      craftctl default
+      # Precompile the staged GSettings schemas so GLib finds a ready
+      # gschemas.compiled at launch instead of emitting repeated schema
+      # symlink/compile warnings on first run. Best-effort: never fail the
+      # build if the schema directory is absent (e.g. provided by the gnome
+      # extension's platform snap).
+      schema_dir="$CRAFT_PRIME/usr/share/glib-2.0/schemas"
+      if [ -d "$schema_dir" ]; then
+        glib-compile-schemas "$schema_dir" || true
+      fi
 
   desktop-assets:
     plugin: dump

--- a/src/discogs_player/ui/main_window.py
+++ b/src/discogs_player/ui/main_window.py
@@ -926,6 +926,7 @@ _SPOTIFY_OAUTH_GUIDE_URL = (
     "https://developer.spotify.com/documentation/web-api/tutorials/code-flow"
 )
 _DISCOGS_TOKEN_URL = "https://www.discogs.com/settings/developers"
+_ISSUES_URL = "https://github.com/edonahue/Discogs_Spinner/issues"
 
 
 def _normalize_release_limit(value: object | None) -> int | None:
@@ -3179,6 +3180,14 @@ class MainWindow(Gtk.ApplicationWindow):
                 "",
                 label="Discogs token page",
                 fallback_url=_DISCOGS_TOKEN_URL,
+            ),
+        )
+        _add_action(
+            "Report a Problem",
+            lambda: self._open_project_doc(
+                "",
+                label="Issue tracker",
+                fallback_url=_ISSUES_URL,
             ),
         )
 

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -14,6 +14,7 @@ async function checkTauriUpdate(): Promise<string | null> {
     return null;
   }
 }
+import { Footer } from "./components/Footer";
 import { Nav } from "./components/Nav";
 import { AnalyticsPage } from "./pages/AnalyticsPage";
 import { CollectionPage } from "./pages/CollectionPage";
@@ -126,6 +127,7 @@ function AppRoutes() {
         <Route path="/analytics" element={<AnalyticsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
+      <Footer />
     </div>
   );
 }

--- a/webapp/src/components/Footer.tsx
+++ b/webapp/src/components/Footer.tsx
@@ -1,0 +1,17 @@
+const ISSUES_URL = "https://github.com/edonahue/Discogs_Spinner/issues";
+
+export function Footer() {
+  return (
+    <footer className="app-footer" aria-label="Support">
+      <span className="app-footer__text">Something not working?</span>
+      <a
+        className="app-footer__link"
+        href={ISSUES_URL}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Report a problem
+      </a>
+    </footer>
+  );
+}

--- a/webapp/src/pages/SetupPage.tsx
+++ b/webapp/src/pages/SetupPage.tsx
@@ -7,6 +7,31 @@ type SetupResponse = {
   discogs: { configured: boolean };
 };
 
+// Mirror the GTK setup wizard's auth-vs-network error differentiation so the
+// same failure reads the same way across the desktop and web surfaces.
+function describeSetupError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : "";
+  const lower = raw.toLowerCase();
+  if (
+    lower.includes("token")
+    || lower.includes("auth")
+    || lower.includes("401")
+    || lower.includes("unauthorized")
+  ) {
+    return "Token rejected — check your token at discogs.com/settings/developers.";
+  }
+  if (
+    lower.includes("network")
+    || lower.includes("connection")
+    || lower.includes("timeout")
+    || lower.includes("failed to fetch")
+    || lower.includes("fetch")
+  ) {
+    return "Network error — check your internet connection and try again.";
+  }
+  return raw || "Could not save token. Please try again.";
+}
+
 export function SetupPage() {
   const navigate = useNavigate();
   const [token, setToken] = useState("");
@@ -34,7 +59,7 @@ export function SetupPage() {
       await postJson<SetupResponse>("/setup", { discogs_token: token });
       navigate("/");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to save token.");
+      setError(describeSetupError(err));
     } finally {
       setSaving(false);
     }

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -100,6 +100,26 @@ button:disabled,
   min-height: 100vh;
 }
 
+.app-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1.5rem 1.25rem 2rem;
+  font-size: 0.85rem;
+  color: rgba(88, 67, 39, 0.6);
+}
+
+.app-footer__link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.app-footer__link:hover {
+  color: rgba(88, 67, 39, 0.95);
+}
+
 .app-nav {
   position: sticky;
   top: 0;


### PR DESCRIPTION
## Summary

PR 3 of 3 from a repo review — FTUX polish.

### F2 — In-app "Report a problem"
- **GTK**: new "Report a Problem" entry in the header help menu, opening the issue tracker via the existing `_open_project_doc` fallback-URL pattern (`main_window.py`).
- **Web**: a persistent `Footer` with a "Report a problem" link, rendered on **all** routes including `/setup` (where the nav is hidden) — so a brand-new user hitting a setup failure can always find it. Directly satisfies v1.0 acceptance criterion #6 ("understand how to report a problem").

### F3 — Setup error copy consistency
- The web `SetupPage` previously showed a generic "Failed to save token". It now mirrors the GTK setup wizard's **auth-vs-network differentiation** (`describeSetupError`), so the same failure reads the same way on desktop and web.

### F1 — Snap first-run warnings
- `snapcraft.yaml` now **precompiles the staged GSettings schemas** at prime time (`glib-compile-schemas` in `override-prime`, guarded best-effort) — the standard fix for the "repeated GLib schema symlink" first-run noise.
- ⚠️ **Needs verification on a real snap rebuild** — I can't reproduce the snap runtime in CI, so this is intentionally the only low-risk, additive change to the live auto-publishing snap. The residual libproxy / COSMIC dconf / IM-module messages originate in the host desktop and aren't fixable from the package. Documented in `STORE_SUBMISSIONS.md`.

## Test plan
- [x] `npm run build` (webapp) passes
- [x] `pytest tests/test_first_run_onboarding.py tests/test_setup_wizard.py tests/test_preferences_window.py` → 55 passed
- [x] `main_window.py` compiles; `snapcraft.yaml` parses as valid YAML; snap-referencing doc tests pass
- [x] Full suite: 676 passed (the 3 remaining failures are pre-existing on `main` and fixed independently in the CI-hardening PR — none are touched here)

## Note
This PR and the store-readiness PR both edit `STORE_SUBMISSIONS.md`, but in different sections (snapshot/Flathub vs. Snap polish), so they should auto-merge. F1's snap change is deliberately scoped narrow pending a verified rebuild — happy to follow up on the remaining warnings once a build confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_