### PR TITLE
ci: enforce ruff + mypy and webapp eslint/prettier/typecheck gates

### DIFF
--- a/.github/workflows/core_plus_ci.yml
+++ b/.github/workflows/core_plus_ci.yml
@@ -10,6 +10,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   PYTHON_VERSION: "3.12"
+  NODE_VERSION: "20"
 
 jobs:
   prepublish-hygiene:
@@ -48,6 +49,38 @@ jobs:
 
       - name: Mypy
         run: mypy src
+
+  webapp-lint:
+    name: Webapp Lint and Type Check
+    needs:
+      - prepublish-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: webapp/package-lock.json
+
+      - name: Install webapp deps
+        working-directory: webapp
+        run: npm ci
+
+      - name: ESLint
+        working-directory: webapp
+        run: npm run lint
+
+      - name: Type check
+        working-directory: webapp
+        run: npm run typecheck
+
+      - name: Prettier check
+        working-directory: webapp
+        run: npm run format:check
 
   test-core:
     name: Test Core Profile

--- a/.github/workflows/core_plus_ci.yml
+++ b/.github/workflows/core_plus_ci.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PYTHON_VERSION: "3.12"
 
 jobs:
   prepublish-hygiene:
@@ -20,6 +21,33 @@ jobs:
 
       - name: Run prepublish hygiene check
         run: bash ./scripts/prepublish_hygiene_check.sh
+
+  lint:
+    name: Lint and Type Check
+    needs:
+      - prepublish-hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install lint tools and typed deps
+        # Install the runtime deps (spotify + web) too so mypy can resolve
+        # third-party imports instead of reporting import-not-found.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[lint,spotify,web]"
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Mypy
+        run: mypy src
 
   test-core:
     name: Test Core Profile
@@ -33,7 +61,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install core profile
         run: |
@@ -64,7 +92,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install plus profile
         run: |
@@ -133,7 +161,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install build tools
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ web = [
 dev = [
   "pytest>=8,<9",
 ]
+lint = [
+  "ruff>=0.15,<0.16",
+  "mypy>=2.1,<3.0",
+]
 
 [project.scripts]
 dplayer = "discogs_player.main:main"

--- a/src/discogs_player/ui/main_window.py
+++ b/src/discogs_player/ui/main_window.py
@@ -1930,7 +1930,8 @@ class MainWindow(Gtk.ApplicationWindow):
     def _on_recent_releases_success(self, data: dict[str, object]) -> None:
         self._recent_releases_loaded = True
         self._recent_releases_widget.set_releases(data)
-        count = len(data.get("releases") or [])
+        releases = data.get("releases")
+        count = len(releases) if isinstance(releases, list) else 0
         self._set_status(f"Showing {count} recently added release{'s' if count != 1 else ''}.")
 
     def _on_recent_releases_error(self, message: str) -> None:

--- a/src/discogs_player/ui/widgets/analytics_panel.py
+++ b/src/discogs_player/ui/widgets/analytics_panel.py
@@ -150,7 +150,7 @@ class AnalyticsPanelWidget(Gtk.Box):
         ]
         col = 0
         for title, rows_raw, label_key in rank_tables:
-            rows = [r for r in rows_raw if isinstance(r, dict)]
+            rows = [r for r in rows_raw if isinstance(r, dict)] if isinstance(rows_raw, list) else []
             widget = self._build_rank_table(title, rows, label_key)
             self._tables_grid.attach(widget, col % 2, col // 2, 1, 1)
             col += 1
@@ -167,7 +167,7 @@ class AnalyticsPanelWidget(Gtk.Box):
             ("Acquisition Timeline", data.get("acquisition_timeline") or []),
         ]
         for title, rows_raw in year_tables:
-            rows = [r for r in rows_raw if isinstance(r, dict)]
+            rows = [r for r in rows_raw if isinstance(r, dict)] if isinstance(rows_raw, list) else []
             widget = self._build_year_table(title, rows)
             widget.set_hexpand(True)
             self._year_box.append(widget)

--- a/src/discogs_player/ui/widgets/home_dashboard.py
+++ b/src/discogs_player/ui/widgets/home_dashboard.py
@@ -154,8 +154,12 @@ class HomeDashboardWidget(Gtk.Box):
 
         # Highlights
         self._clear_box(self._highlights_box)
-        highlights_raw = data.get("highlights") or []
-        highlights = [h for h in highlights_raw if isinstance(h, dict)]
+        highlights_raw = data.get("highlights")
+        highlights = (
+            [h for h in highlights_raw if isinstance(h, dict)]
+            if isinstance(highlights_raw, list)
+            else []
+        )
         if highlights:
             for h in highlights[:5]:
                 row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -173,8 +177,12 @@ class HomeDashboardWidget(Gtk.Box):
 
         # Hidden gems
         self._clear_box(self._gems_box)
-        gems_raw = data.get("top_hidden_gems") or []
-        gems = [g for g in gems_raw if isinstance(g, dict)]
+        gems_raw = data.get("top_hidden_gems")
+        gems = (
+            [g for g in gems_raw if isinstance(g, dict)]
+            if isinstance(gems_raw, list)
+            else []
+        )
         if gems:
             for gem in gems:
                 row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)

--- a/src/discogs_player/ui/widgets/recent_releases.py
+++ b/src/discogs_player/ui/widgets/recent_releases.py
@@ -108,8 +108,12 @@ class RecentReleasesWidget(Gtk.Box):
         self._clear_list()
         self._status_label.set_visible(False)
 
-        releases_raw = data.get("releases") or []
-        releases = [r for r in releases_raw if isinstance(r, dict)]
+        releases_raw = data.get("releases")
+        releases = (
+            [r for r in releases_raw if isinstance(r, dict)]
+            if isinstance(releases_raw, list)
+            else []
+        )
 
         if not releases:
             self._status_label.set_text("No releases added in this period.")

--- a/src/discogs_player_api/routers/share.py
+++ b/src/discogs_player_api/routers/share.py
@@ -8,7 +8,7 @@ from fastapi.responses import PlainTextResponse
 from discogs_player.use_cases.collection_analytics import run_collection_analytics
 from discogs_player.use_cases.export import _analytics_to_markdown, _value_to_markdown
 from discogs_player.use_cases.value_status import run_market_value_status
-from discogs_player_api.runtime import run_use_case
+from discogs_player_api.runtime import run_use_case_raw
 
 router = APIRouter(tags=["share"])
 
@@ -22,7 +22,7 @@ def api_share_collection_markdown(
         report = run_collection_analytics(limit=limit)
         return _analytics_to_markdown(report)
 
-    return run_use_case(_payload)
+    return run_use_case_raw(_payload)
 
 
 @router.get("/share/value/markdown", response_class=PlainTextResponse)
@@ -32,4 +32,4 @@ def api_share_value_markdown() -> str:
         summary = run_market_value_status()
         return _value_to_markdown(summary)
 
-    return run_use_case(_payload)
+    return run_use_case_raw(_payload)

--- a/src/discogs_player_api/runtime.py
+++ b/src/discogs_player_api/runtime.py
@@ -22,3 +22,16 @@ def run_use_case(
     except Exception as exc:  # noqa: BLE001 - centralized API mapping.
         raise_http_exception_for(exc)
     return success_envelope(with_provider_mapping_aliases(data), meta=meta)
+
+
+def run_use_case_raw(call: Callable[[], T]) -> T:
+    """Run a use-case with centralized error mapping but return its raw result.
+
+    Use for endpoints that serve content directly (e.g. ``PlainTextResponse``
+    markdown) rather than the standard JSON success envelope.
+    """
+    try:
+        return call()
+    except Exception as exc:  # noqa: BLE001 - centralized API mapping.
+        raise_http_exception_for(exc)
+        raise  # unreachable: raise_http_exception_for always raises

--- a/tests/test_api_service.py
+++ b/tests/test_api_service.py
@@ -8,7 +8,7 @@ fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from discogs_player_api.app import create_app
-from discogs_player_api.routers import catalog, matching, status, sync
+from discogs_player_api.routers import catalog, matching, share, status, sync
 from discogs_player_api.routers import value as value_router
 
 # ---------------------------------------------------------------------------
@@ -500,3 +500,31 @@ def test_api_validation_errors_use_standard_error_envelope():
     assert body["ok"] is False
     assert body["error"]["code"] == "request_validation_failed"
     assert isinstance(body["error"]["details"], dict)
+
+
+# ---------------------------------------------------------------------------
+# Share (markdown) — returns raw text, not the JSON envelope
+# ---------------------------------------------------------------------------
+
+
+def test_api_share_collection_markdown_returns_raw_markdown(monkeypatch):
+    monkeypatch.setattr(share, "run_collection_analytics", lambda **_: {})
+    monkeypatch.setattr(share, "_analytics_to_markdown", lambda _report: "# Collection\n\nbody")
+
+    client = TestClient(create_app())
+    response = client.get("/api/v1/share/collection/markdown")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    # Raw markdown, not wrapped in the {"ok": ..., "data": ...} envelope.
+    assert response.text == "# Collection\n\nbody"
+
+
+def test_api_share_value_markdown_returns_raw_markdown(monkeypatch):
+    monkeypatch.setattr(share, "run_market_value_status", lambda: {})
+    monkeypatch.setattr(share, "_value_to_markdown", lambda _summary: "# Value\n\nbody")
+
+    client = TestClient(create_app())
+    response = client.get("/api/v1/share/value/markdown")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.text == "# Value\n\nbody"

--- a/webapp/.prettierignore
+++ b/webapp/.prettierignore
@@ -1,0 +1,4 @@
+dist
+playwright-report
+test-results
+node_modules

--- a/webapp/.prettierrc.json
+++ b/webapp/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/webapp/e2e/smoke.spec.ts
+++ b/webapp/e2e/smoke.spec.ts
@@ -38,10 +38,7 @@ import {
 
 const SAVE_SCREENSHOTS = !!process.env.SAVE_SCREENSHOTS;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCREENSHOT_DIR = path.resolve(
-  __dirname,
-  "../../docs/media/screenshots/webapp"
-);
+const SCREENSHOT_DIR = path.resolve(__dirname, "../../docs/media/screenshots/webapp");
 
 function fulfill(route: Route, json: unknown) {
   return route.fulfill({
@@ -74,11 +71,9 @@ async function mockSetup(page: Page) {
 }
 
 async function mockCollectionRoutes(page: Page) {
-  await page.route("**/api/v1/releases/summary?**", (r) =>
-    fulfill(r, STUB_COLLECTION_SUMMARY)
-  );
+  await page.route("**/api/v1/releases/summary?**", (r) => fulfill(r, STUB_COLLECTION_SUMMARY));
   await page.route("**/api/v1/releases/1?with_value=true", (r) =>
-    fulfill(r, STUB_COLLECTION_DETAIL)
+    fulfill(r, STUB_COLLECTION_DETAIL),
   );
   await page.route("**/api/v1/releases/2?with_value=true", (r) =>
     fulfill(r, {
@@ -90,31 +85,23 @@ async function mockCollectionRoutes(page: Page) {
         artist: "Stevie Wonder",
         year: 1973,
       },
-    })
+    }),
   );
-  await page.route("**/api/v1/releases/1/tracklist**", (r) =>
-    fulfill(r, STUB_TRACKLIST)
-  );
+  await page.route("**/api/v1/releases/1/tracklist**", (r) => fulfill(r, STUB_TRACKLIST));
   await page.route("**/api/v1/releases?**", (r) => fulfill(r, STUB_COLLECTION));
 }
 
 async function mockWantlistRoutes(page: Page) {
   await page.route("**/api/v1/wantlist/10?with_value=true", (r) =>
-    fulfill(r, STUB_WANTLIST_DETAIL)
+    fulfill(r, STUB_WANTLIST_DETAIL),
   );
   await page.route("**/api/v1/wantlist?**", (r) => fulfill(r, STUB_WANTLIST));
 }
 
 async function mockValueRoutes(page: Page) {
-  await page.route("**/api/v1/value/dashboard**", (r) =>
-    fulfill(r, STUB_VALUE_DASHBOARD)
-  );
-  await page.route("**/api/v1/value/queue**", (r) =>
-    fulfill(r, STUB_VALUE_QUEUE)
-  );
-  await page.route("**/api/v1/value/gems**", (r) =>
-    fulfill(r, STUB_HIDDEN_GEMS)
-  );
+  await page.route("**/api/v1/value/dashboard**", (r) => fulfill(r, STUB_VALUE_DASHBOARD));
+  await page.route("**/api/v1/value/queue**", (r) => fulfill(r, STUB_VALUE_QUEUE));
+  await page.route("**/api/v1/value/gems**", (r) => fulfill(r, STUB_HIDDEN_GEMS));
 }
 
 async function saveScreenshot(page: Page, filename: string) {
@@ -163,7 +150,7 @@ test("Value page renders top releases", async ({ page }) => {
   await expect(page.getByText("Kind of Blue")).toBeVisible();
   await expect(page.getByText("Hidden Gems")).toBeVisible();
   await expect(
-    page.locator("section").filter({ hasText: "Hidden Gems" }).getByText("Innervisions")
+    page.locator("section").filter({ hasText: "Hidden Gems" }).getByText("Innervisions"),
   ).toBeVisible();
   await expect(page.getByRole("link", { name: "View in Collection" }).first()).toBeVisible();
 });
@@ -171,14 +158,10 @@ test("Value page renders top releases", async ({ page }) => {
 test("Value page keeps top releases visible if Hidden Gems fails", async ({ page }) => {
   await mockSetup(page);
   await mockCollectionRoutes(page);
-  await page.route("**/api/v1/value/dashboard**", (r) =>
-    fulfill(r, STUB_VALUE_DASHBOARD)
-  );
-  await page.route("**/api/v1/value/queue**", (r) =>
-    fulfill(r, STUB_VALUE_QUEUE)
-  );
+  await page.route("**/api/v1/value/dashboard**", (r) => fulfill(r, STUB_VALUE_DASHBOARD));
+  await page.route("**/api/v1/value/queue**", (r) => fulfill(r, STUB_VALUE_QUEUE));
   await page.route("**/api/v1/value/gems**", (r) =>
-    fulfillError(r, "Hidden Gems unavailable.", 503)
+    fulfillError(r, "Hidden Gems unavailable.", 503),
   );
 
   await page.goto("/value");
@@ -191,9 +174,7 @@ test("Value page keeps top releases visible if Hidden Gems fails", async ({ page
 
 test("Collection Health page renders score", async ({ page }) => {
   await mockSetup(page);
-  await page.route("**/api/v1/value/health**", (r) =>
-    fulfill(r, STUB_HEALTH)
-  );
+  await page.route("**/api/v1/value/health**", (r) => fulfill(r, STUB_HEALTH));
 
   await page.goto("/health");
   await expect(page.locator("h1")).toHaveText("Collection Health");
@@ -207,9 +188,7 @@ test("Collection Health page renders score", async ({ page }) => {
 test("Recently Added page renders releases", async ({ page }) => {
   await mockSetup(page);
   await mockCollectionRoutes(page);
-  await page.route("**/api/v1/releases/recent**", (r) =>
-    fulfill(r, STUB_RECENT)
-  );
+  await page.route("**/api/v1/releases/recent**", (r) => fulfill(r, STUB_RECENT));
 
   await page.goto("/recent");
   await expect(page.locator("h1")).toHaveText("Recently Added");
@@ -224,15 +203,13 @@ test("Recently Added page renders releases", async ({ page }) => {
 
 test("Collection Analytics page renders stats", async ({ page }) => {
   await mockSetup(page);
-  await page.route("**/api/v1/analytics**", (r) =>
-    fulfill(r, STUB_ANALYTICS)
-  );
+  await page.route("**/api/v1/analytics**", (r) => fulfill(r, STUB_ANALYTICS));
 
   await page.goto("/analytics");
   await expect(page.locator("h1")).toHaveText("Collection Analytics");
   // Summary counters
-  await expect(page.getByText("150")).toBeVisible();  // release_count_active
-  await expect(page.getByText("120")).toBeVisible();  // mapped_count
+  await expect(page.getByText("150")).toBeVisible(); // release_count_active
+  await expect(page.getByText("120")).toBeVisible(); // mapped_count
   // Top genres table heading
   await expect(page.getByText("Top Genres")).toBeVisible();
 
@@ -269,9 +246,7 @@ test("Value page handoff opens focused collection detail", async ({ page }) => {
 test("Recent page handoff opens focused collection detail", async ({ page }) => {
   await mockSetup(page);
   await mockCollectionRoutes(page);
-  await page.route("**/api/v1/releases/recent**", (r) =>
-    fulfill(r, STUB_RECENT)
-  );
+  await page.route("**/api/v1/releases/recent**", (r) => fulfill(r, STUB_RECENT));
 
   await page.goto("/recent");
   await page.getByRole("link", { name: "View in Collection" }).first().click();
@@ -349,12 +324,16 @@ test("Home page sync buttons await completion and refresh status", async ({ page
 
   releaseCollectionSync?.();
 
-  await expect(page.getByText("Collection sync complete: fetched 4, upserted 4, deactivated 0.")).toBeVisible();
+  await expect(
+    page.getByText("Collection sync complete: fetched 4, upserted 4, deactivated 0."),
+  ).toBeVisible();
   await expect(syncCollectionButton).toBeEnabled();
   await expect(activeCard).toContainText("4");
 
   await page.locator(".app-inline-actions button").nth(1).click();
-  await expect(page.getByText("Wantlist sync complete: fetched 2, upserted 2, deactivated 0.")).toBeVisible();
+  await expect(
+    page.getByText("Wantlist sync complete: fetched 2, upserted 2, deactivated 0."),
+  ).toBeVisible();
   await expect(wantlistCard).toContainText("2");
 });
 
@@ -364,14 +343,10 @@ test("Collection page sync reloads releases and preserves focused detail", async
   let collectionPayload = STUB_COLLECTION;
   let collectionSummaryPayload = STUB_COLLECTION_SUMMARY;
   await page.route("**/api/v1/releases/1?with_value=true", (r) =>
-    fulfill(r, STUB_COLLECTION_DETAIL)
+    fulfill(r, STUB_COLLECTION_DETAIL),
   );
-  await page.route("**/api/v1/releases/1/tracklist**", (r) =>
-    fulfill(r, STUB_TRACKLIST)
-  );
-  await page.route("**/api/v1/releases/summary?**", (r) =>
-    fulfill(r, collectionSummaryPayload)
-  );
+  await page.route("**/api/v1/releases/1/tracklist**", (r) => fulfill(r, STUB_TRACKLIST));
+  await page.route("**/api/v1/releases/summary?**", (r) => fulfill(r, collectionSummaryPayload));
   await page.route("**/api/v1/releases?**", (r) => fulfill(r, collectionPayload));
   await page.route("**/api/v1/sync/collection", async (r) => {
     collectionPayload = STUB_COLLECTION_AFTER_SYNC;
@@ -384,7 +359,9 @@ test("Collection page sync reloads releases and preserves focused detail", async
 
   await page.getByRole("button", { name: "Sync Collection" }).click();
 
-  await expect(page.getByText("Collection sync complete: fetched 4, upserted 4, deactivated 0.")).toBeVisible();
+  await expect(
+    page.getByText("Collection sync complete: fetched 4, upserted 4, deactivated 0."),
+  ).toBeVisible();
   await expect(page.locator("li")).toHaveCount(4);
   await expect(page).toHaveURL(/\/collection\?focus=1$/);
   await expect(page.getByText("Focused Collection Detail")).toBeVisible();
@@ -397,7 +374,7 @@ test("Wantlist page sync reloads entries and preserves focused detail", async ({
 
   let wantlistPayload = STUB_WANTLIST;
   await page.route("**/api/v1/wantlist/10?with_value=true", (r) =>
-    fulfill(r, STUB_WANTLIST_DETAIL)
+    fulfill(r, STUB_WANTLIST_DETAIL),
   );
   await page.route("**/api/v1/wantlist?**", (r) => fulfill(r, wantlistPayload));
   await page.route("**/api/v1/sync/wantlist", async (r) => {
@@ -410,7 +387,9 @@ test("Wantlist page sync reloads entries and preserves focused detail", async ({
 
   await page.getByRole("button", { name: "Sync Wantlist" }).click();
 
-  await expect(page.getByText("Wantlist sync complete: fetched 2, upserted 2, deactivated 0.")).toBeVisible();
+  await expect(
+    page.getByText("Wantlist sync complete: fetched 2, upserted 2, deactivated 0."),
+  ).toBeVisible();
   await expect(page.locator("li")).toHaveCount(2);
   await expect(page).toHaveURL(/\/wantlist\?focus=10$/);
   await expect(page.getByText("Focused Wantlist Detail")).toBeVisible();
@@ -421,7 +400,7 @@ test("Collection page sync failure keeps the current list visible", async ({ pag
   await mockSetup(page);
   await mockCollectionRoutes(page);
   await page.route("**/api/v1/sync/collection", (r) =>
-    fulfillError(r, "Discogs collection sync failed.", 503)
+    fulfillError(r, "Discogs collection sync failed.", 503),
   );
 
   await page.goto("/collection");

--- a/webapp/eslint.config.js
+++ b/webapp/eslint.config.js
@@ -1,0 +1,32 @@
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  { ignores: ["dist", "playwright-report", "test-results"] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    },
+  },
+  // e2e tests run under Node + Playwright globals.
+  {
+    files: ["e2e/**/*.{ts,tsx}", "playwright.config.ts"],
+    languageOptions: {
+      globals: { ...globals.node },
+    },
+  },
+);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,11 +14,18 @@
         "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.49.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "eslint": "^9.39.4",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.26",
+        "globals": "^15.15.0",
+        "prettier": "^3.9.0",
         "typescript": "^5.6.2",
+        "typescript-eslint": "^8.62.0",
         "vite": "^5.4.8"
       }
     },
@@ -695,6 +702,229 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1180,6 +1410,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1208,6 +1445,301 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1229,6 +1761,76 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -1240,6 +1842,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/browserslist": {
@@ -1276,6 +1889,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001774",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
@@ -1297,6 +1920,50 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1315,6 +1982,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/csstype": {
@@ -1341,6 +2023,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -1398,6 +2087,286 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1423,11 +2392,137 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1442,6 +2537,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1454,6 +2570,53 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1475,6 +2638,19 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -1503,6 +2679,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -1510,12 +2693,108 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/playwright": {
       "version": "1.58.2",
@@ -1593,6 +2872,42 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.0.tgz",
+      "integrity": "sha512-LjIqSIC5VYLzs9WedVmJ2ljNAGnU+DteIClbahu4L/DBeWjZ6iT/k1lAYyu9JUh+1xINxWadaPw/Pl63y/agAw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1666,6 +2981,16 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1736,6 +3061,29 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1744,6 +3092,75 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/typescript": {
@@ -1758,6 +3175,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1789,6 +3230,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/vite": {
@@ -1851,12 +3302,51 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -7,6 +7,10 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"e2e/**/*.ts\" \"*.{ts,js,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"e2e/**/*.ts\" \"*.{ts,js,json}\"",
     "test:e2e": "playwright test",
     "test:e2e:screenshots": "SAVE_SCREENSHOTS=1 playwright test"
   },
@@ -17,11 +21,18 @@
     "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.49.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^9.39.4",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^15.15.0",
+    "prettier": "^3.9.0",
     "typescript": "^5.6.2",
+    "typescript-eslint": "^8.62.0",
     "vite": "^5.4.8"
   }
 }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -79,12 +79,13 @@ function AppRoutes() {
       return getJson<SetupPayload>("/setup")
         .then((payload) => {
           const readinessSummary = payload.data?.provider_readiness?.summary;
-          const onboardingStage = readinessSummary?.onboarding_state ?? payload.data?.onboarding_stage;
+          const onboardingStage =
+            readinessSummary?.onboarding_state ?? payload.data?.onboarding_stage;
           const requiredConfigured = readinessSummary?.required_services_configured;
           if (
-            onboardingStage === "needs_required_setup"
-            || onboardingStage === "needs_discogs_token"
-            || requiredConfigured === false
+            onboardingStage === "needs_required_setup" ||
+            onboardingStage === "needs_discogs_token" ||
+            requiredConfigured === false
           ) {
             navigate("/setup", { replace: true });
           }
@@ -92,14 +93,18 @@ function AppRoutes() {
         .catch(() => {
           if (attemptsLeft > 1) {
             return new Promise<void>((resolve) => {
-              setTimeout(() => { resolve(checkSetup(attemptsLeft - 1)); }, RETRY_DELAY_MS);
+              setTimeout(() => {
+                resolve(checkSetup(attemptsLeft - 1));
+              }, RETRY_DELAY_MS);
             });
           }
           // All retries exhausted — API unreachable; let routes render normally.
         });
     }
 
-    checkSetup(MAX_ATTEMPTS).finally(() => { setChecked(true); });
+    checkSetup(MAX_ATTEMPTS).finally(() => {
+      setChecked(true);
+    });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!checked) {

--- a/webapp/src/api.ts
+++ b/webapp/src/api.ts
@@ -107,8 +107,8 @@ export async function getJson<T>(
     method: "GET",
     signal: options.signal,
     headers: {
-      "Accept": "application/json"
-    }
+      Accept: "application/json",
+    },
   });
   const payload = (await response.json()) as ApiEnvelope<T>;
   if (!response.ok || !payload.ok) {
@@ -127,7 +127,7 @@ export async function postJson<T>(
     method: "POST",
     signal: options.signal,
     headers: {
-      "Accept": "application/json",
+      Accept: "application/json",
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
@@ -329,10 +329,13 @@ export interface CollectionHealth {
   buckets: HealthBucket[];
 }
 
-export function fetchValueQueue(params?: {
-  limit?: number;
-  stale_days?: number;
-}, options: RequestOptions = {}): Promise<ApiEnvelope<ValueRefreshQueue>> {
+export function fetchValueQueue(
+  params?: {
+    limit?: number;
+    stale_days?: number;
+  },
+  options: RequestOptions = {},
+): Promise<ApiEnvelope<ValueRefreshQueue>> {
   const qs = new URLSearchParams();
   if (params?.limit != null) qs.set("limit", String(params.limit));
   if (params?.stale_days != null) qs.set("stale_days", String(params.stale_days));
@@ -366,10 +369,13 @@ export interface HiddenGemsPayload {
   gems: HiddenGem[];
 }
 
-export function fetchHiddenGems(params?: {
-  min_median?: number;
-  limit?: number;
-}, options: RequestOptions = {}): Promise<ApiEnvelope<HiddenGemsPayload>> {
+export function fetchHiddenGems(
+  params?: {
+    min_median?: number;
+    limit?: number;
+  },
+  options: RequestOptions = {},
+): Promise<ApiEnvelope<HiddenGemsPayload>> {
   const qs = new URLSearchParams();
   if (params?.min_median != null) qs.set("min_median", String(params.min_median));
   if (params?.limit != null) qs.set("limit", String(params.limit));
@@ -400,9 +406,18 @@ export interface AnalyticsYearRow {
   year: number;
   count: number;
 }
-export interface AnalyticsGenreRow { genre: string; count: number; }
-export interface AnalyticsStyleRow { style: string; count: number; }
-export interface AnalyticsArtistRow { artist: string; count: number; }
+export interface AnalyticsGenreRow {
+  genre: string;
+  count: number;
+}
+export interface AnalyticsStyleRow {
+  style: string;
+  count: number;
+}
+export interface AnalyticsArtistRow {
+  artist: string;
+  count: number;
+}
 
 export interface CollectionAnalytics {
   release_count_active: number;
@@ -464,11 +479,14 @@ export interface CollectorInsightsPayload {
   top_hidden_gems: CollectorInsightGem[];
 }
 
-export function fetchCollectorInsights(params?: {
-  gems_limit?: number;
-  queue_limit?: number;
-  min_median?: number;
-}, options: RequestOptions = {}): Promise<ApiEnvelope<CollectorInsightsPayload>> {
+export function fetchCollectorInsights(
+  params?: {
+    gems_limit?: number;
+    queue_limit?: number;
+    min_median?: number;
+  },
+  options: RequestOptions = {},
+): Promise<ApiEnvelope<CollectorInsightsPayload>> {
   const qs = new URLSearchParams();
   if (params?.gems_limit != null) qs.set("gems_limit", String(params.gems_limit));
   if (params?.queue_limit != null) qs.set("queue_limit", String(params.queue_limit));
@@ -496,15 +514,11 @@ export interface TracklistPayload {
   tracklist_last_refreshed_at: string | null;
 }
 
-export function fetchTracklist(
-  releaseId: number,
-): Promise<ApiEnvelope<TracklistPayload>> {
+export function fetchTracklist(releaseId: number): Promise<ApiEnvelope<TracklistPayload>> {
   return getJson<TracklistPayload>(`/releases/${releaseId}/tracklist`);
 }
 
-export function refreshTracklist(
-  releaseId: number,
-): Promise<ApiEnvelope<TracklistPayload>> {
+export function refreshTracklist(releaseId: number): Promise<ApiEnvelope<TracklistPayload>> {
   return postJson<TracklistPayload>(`/releases/${releaseId}/tracklist/refresh`, {});
 }
 
@@ -520,9 +534,7 @@ export interface SpinParams {
   unmatched?: boolean;
 }
 
-export function spinCollection(
-  params: SpinParams,
-): Promise<ApiEnvelope<SpinResult>> {
+export function spinCollection(params: SpinParams): Promise<ApiEnvelope<SpinResult>> {
   const qs = new URLSearchParams();
   if (params.q) qs.set("q", params.q);
   if (params.year) qs.set("year", params.year);
@@ -532,9 +544,7 @@ export function spinCollection(
   return postJson<SpinResult>(`/releases/spin${suffix}`, {});
 }
 
-export function spinWantlist(
-  params: SpinParams,
-): Promise<ApiEnvelope<SpinResult>> {
+export function spinWantlist(params: SpinParams): Promise<ApiEnvelope<SpinResult>> {
   const qs = new URLSearchParams();
   if (params.q) qs.set("q", params.q);
   if (params.year) qs.set("year", params.year);

--- a/webapp/src/components/FocusedReleaseCard.tsx
+++ b/webapp/src/components/FocusedReleaseCard.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  fetchReleaseDetail,
-  fetchWantlistDetail,
-  ReleaseDetail,
-} from "../api";
+import { fetchReleaseDetail, fetchWantlistDetail, ReleaseDetail } from "../api";
 
 type FocusScope = "collection" | "wantlist";
 
@@ -15,7 +11,10 @@ type Props = {
   spinAnimating?: boolean;
 };
 
-function formatCurrency(value: number | null | undefined, currency: string | null | undefined): string {
+function formatCurrency(
+  value: number | null | undefined,
+  currency: string | null | undefined,
+): string {
   if (value == null) return "Not priced";
   const normalizedCurrency = (currency || "USD").trim() || "USD";
   try {
@@ -56,7 +55,13 @@ function discogsReleaseUrl(releaseId: number): string {
   return `https://www.discogs.com/release/${releaseId}`;
 }
 
-export function FocusedReleaseCard({ releaseId, scope, onClear, onOpenTracklist, spinAnimating }: Props) {
+export function FocusedReleaseCard({
+  releaseId,
+  scope,
+  onClear,
+  onOpenTracklist,
+  spinAnimating,
+}: Props) {
   const [release, setRelease] = useState<ReleaseDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -66,9 +71,10 @@ export function FocusedReleaseCard({ releaseId, scope, onClear, onOpenTracklist,
     setLoading(true);
     setError("");
 
-    const request = scope === "wantlist"
-      ? fetchWantlistDetail(releaseId, { withValue: true })
-      : fetchReleaseDetail(releaseId, { withValue: true });
+    const request =
+      scope === "wantlist"
+        ? fetchWantlistDetail(releaseId, { withValue: true })
+        : fetchReleaseDetail(releaseId, { withValue: true });
 
     request
       .then((payload) => {
@@ -96,9 +102,14 @@ export function FocusedReleaseCard({ releaseId, scope, onClear, onOpenTracklist,
   const scopeLabel = scope === "wantlist" ? "Focused Wantlist Detail" : "Focused Collection Detail";
 
   return (
-    <section className={`app-surface app-focus-card${spinAnimating ? " app-focus-card--spin-result" : ""}`} aria-live="polite">
+    <section
+      className={`app-surface app-focus-card${spinAnimating ? " app-focus-card--spin-result" : ""}`}
+      aria-live="polite"
+    >
       <p className="app-focus-card__eyebrow">{scopeLabel}</p>
-      {loading ? <p className="app-message app-message--subtle">Loading release #{releaseId}…</p> : null}
+      {loading ? (
+        <p className="app-message app-message--subtle">Loading release #{releaseId}…</p>
+      ) : null}
       {error ? <p className="app-message app-message--error">{error}</p> : null}
       {!loading && !error && release ? (
         <div className="app-card-stack">
@@ -116,7 +127,9 @@ export function FocusedReleaseCard({ releaseId, scope, onClear, onOpenTracklist,
           {release.genres.length > 0 || release.styles.length > 0 ? (
             <div className="app-tag-list">
               {[...release.genres, ...release.styles].slice(0, 6).map((tag) => (
-                <span key={tag} className="app-tag">{tag}</span>
+                <span key={tag} className="app-tag">
+                  {tag}
+                </span>
               ))}
             </div>
           ) : null}
@@ -138,9 +151,7 @@ export function FocusedReleaseCard({ releaseId, scope, onClear, onOpenTracklist,
             </div>
           </div>
 
-          {release.notes ? (
-            <p className="app-focus-card__note">{release.notes}</p>
-          ) : null}
+          {release.notes ? <p className="app-focus-card__note">{release.notes}</p> : null}
 
           <div className="app-card-actions">
             {onOpenTracklist ? (

--- a/webapp/src/components/Footer.tsx
+++ b/webapp/src/components/Footer.tsx
@@ -4,12 +4,7 @@ export function Footer() {
   return (
     <footer className="app-footer" aria-label="Support">
       <span className="app-footer__text">Something not working?</span>
-      <a
-        className="app-footer__link"
-        href={ISSUES_URL}
-        target="_blank"
-        rel="noreferrer"
-      >
+      <a className="app-footer__link" href={ISSUES_URL} target="_blank" rel="noreferrer">
         Report a problem
       </a>
     </footer>

--- a/webapp/src/components/Nav.tsx
+++ b/webapp/src/components/Nav.tsx
@@ -2,7 +2,16 @@ import { NavLink } from "react-router-dom";
 
 function IconHome() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <path d="M2 6.5L8 2l6 4.5V14a1 1 0 01-1 1H3a1 1 0 01-1-1V6.5z" />
       <path d="M6 15V9h4v6" />
     </svg>
@@ -11,7 +20,16 @@ function IconHome() {
 
 function IconCollection() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <circle cx="8" cy="8" r="6" />
       <circle cx="8" cy="8" r="1.5" />
       <path d="M8 2a6 6 0 010 12" strokeDasharray="2 2" />
@@ -21,7 +39,16 @@ function IconCollection() {
 
 function IconWantlist() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <path d="M8 13.5S2 9.5 2 5.5A3.5 3.5 0 018 3.2 3.5 3.5 0 0114 5.5c0 4-6 8-6 8z" />
     </svg>
   );
@@ -29,7 +56,16 @@ function IconWantlist() {
 
 function IconValue() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <path d="M8 1v14M5 4h4.5a2 2 0 010 4H5m0 0h5a2 2 0 010 4H5" />
     </svg>
   );
@@ -37,7 +73,16 @@ function IconValue() {
 
 function IconHealth() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <path d="M1 8h3l2-5 3 10 2-5h4" />
     </svg>
   );
@@ -45,7 +90,16 @@ function IconHealth() {
 
 function IconRecent() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <circle cx="8" cy="8" r="6" />
       <path d="M8 5v3.5l2.5 1.5" />
     </svg>
@@ -54,7 +108,16 @@ function IconRecent() {
 
 function IconAnalytics() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <rect x="1" y="10" width="3" height="5" rx="0.5" />
       <rect x="6.5" y="6" width="3" height="9" rx="0.5" />
       <rect x="12" y="2" width="3" height="13" rx="0.5" />
@@ -64,7 +127,16 @@ function IconAnalytics() {
 
 function IconSetup() {
   return (
-    <svg className="app-nav__icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg
+      className="app-nav__icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
       <circle cx="8" cy="8" r="2" />
       <path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.42 1.42M11.54 11.54l1.41 1.41M3.05 12.95l1.42-1.42M11.54 4.46l1.41-1.41" />
     </svg>
@@ -80,28 +152,36 @@ export function Nav() {
     <nav className="app-nav" aria-label="Primary">
       <div className="app-nav__inner">
         <NavLink to="/" end className={({ isActive }) => navClass(isActive)}>
-          <IconHome />Home
+          <IconHome />
+          Home
         </NavLink>
         <NavLink to="/collection" className={({ isActive }) => navClass(isActive)}>
-          <IconCollection />Collection
+          <IconCollection />
+          Collection
         </NavLink>
         <NavLink to="/wantlist" className={({ isActive }) => navClass(isActive)}>
-          <IconWantlist />Wantlist
+          <IconWantlist />
+          Wantlist
         </NavLink>
         <NavLink to="/value" className={({ isActive }) => navClass(isActive)}>
-          <IconValue />Value
+          <IconValue />
+          Value
         </NavLink>
         <NavLink to="/health" className={({ isActive }) => navClass(isActive)}>
-          <IconHealth />Health
+          <IconHealth />
+          Health
         </NavLink>
         <NavLink to="/recent" className={({ isActive }) => navClass(isActive)}>
-          <IconRecent />Recent
+          <IconRecent />
+          Recent
         </NavLink>
         <NavLink to="/analytics" className={({ isActive }) => navClass(isActive)}>
-          <IconAnalytics />Analytics
+          <IconAnalytics />
+          Analytics
         </NavLink>
         <NavLink to="/setup" className={({ isActive }) => navClass(isActive)}>
-          <IconSetup />Setup
+          <IconSetup />
+          Setup
         </NavLink>
       </div>
     </nav>

--- a/webapp/src/components/TracklistModal.tsx
+++ b/webapp/src/components/TracklistModal.tsx
@@ -26,7 +26,7 @@ export function TracklistModal({ releaseId, releaseTitle, releaseArtist, onClose
         setHasCached(d?.has_cached_tracklist ?? false);
       })
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to load tracklist.")
+        setError(err instanceof Error ? err.message : "Failed to load tracklist."),
       )
       .finally(() => setLoading(false));
   }
@@ -45,7 +45,7 @@ export function TracklistModal({ releaseId, releaseTitle, releaseArtist, onClose
         setHasCached(d?.has_cached_tracklist ?? false);
       })
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to refresh tracklist.")
+        setError(err instanceof Error ? err.message : "Failed to refresh tracklist."),
       )
       .finally(() => setRefreshing(false));
   }
@@ -65,16 +65,14 @@ export function TracklistModal({ releaseId, releaseTitle, releaseArtist, onClose
   const audioTracks = tracks.filter((t) => t.type_ !== "heading");
 
   return (
-    <div
-      ref={backdropRef}
-      onClick={handleBackdropClick}
-      className="app-modal"
-    >
+    <div ref={backdropRef} onClick={handleBackdropClick} className="app-modal">
       <div className="app-modal__panel">
         <div className="app-modal__header">
           <div>
             <strong style={{ fontSize: "1.05rem" }}>{releaseArtist}</strong>
-            <div className="app-muted" style={{ marginTop: "0.1rem" }}>{releaseTitle}</div>
+            <div className="app-muted" style={{ marginTop: "0.1rem" }}>
+              {releaseTitle}
+            </div>
           </div>
           <button
             onClick={onClose}
@@ -89,7 +87,10 @@ export function TracklistModal({ releaseId, releaseTitle, releaseArtist, onClose
         {loading ? <p className="app-message app-message--subtle">Loading…</p> : null}
 
         {!loading && !error && !hasCached ? (
-          <div className="app-message app-message--subtle" style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+          <div
+            className="app-message app-message--subtle"
+            style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}
+          >
             <span>Tracklist not yet loaded.</span>
             <button
               type="button"
@@ -122,7 +123,9 @@ export function TracklistModal({ releaseId, releaseTitle, releaseArtist, onClose
                   <tr key={i}>
                     <td data-label="Track">{track.position || String(i + 1)}</td>
                     <td data-label="Title">{track.title}</td>
-                    <td data-label="Duration" className="is-right">{track.duration || "—"}</td>
+                    <td data-label="Duration" className="is-right">
+                      {track.duration || "—"}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -7,5 +7,5 @@ import "./styles.css";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/webapp/src/pages/AnalyticsPage.tsx
+++ b/webapp/src/pages/AnalyticsPage.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import { CollectionAnalytics, fetchAnalytics } from "../api";
 
-function RankTable({
+function RankTable<T extends { count: number }>({
   title,
   rows,
   labelKey,
 }: {
   title: string;
-  rows: { count: number; [key: string]: string | number }[];
-  labelKey: string;
+  rows: T[];
+  labelKey: keyof T & string;
 }) {
   return (
     <div style={{ marginBottom: "2rem" }}>
@@ -18,22 +18,26 @@ function RankTable({
       ) : (
         <div className="app-table-wrap">
           <table className="app-table app-table--compact responsive-stack app-rank-table">
-          <thead>
-            <tr>
-              <th>Rank</th>
-              <th>Name</th>
-              <th className="is-right">Releases</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row, i) => (
-              <tr key={String(row[labelKey])}>
-                <td data-label="Rank" style={{ color: "#aaa", width: "2rem" }}>{i + 1}</td>
-                <td data-label="Name">{String(row[labelKey])}</td>
-                <td data-label="Releases" className="is-right">{row.count}</td>
+            <thead>
+              <tr>
+                <th>Rank</th>
+                <th>Name</th>
+                <th className="is-right">Releases</th>
               </tr>
-            ))}
-          </tbody>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr key={String(row[labelKey])}>
+                  <td data-label="Rank" style={{ color: "#aaa", width: "2rem" }}>
+                    {i + 1}
+                  </td>
+                  <td data-label="Name">{String(row[labelKey])}</td>
+                  <td data-label="Releases" className="is-right">
+                    {row.count}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
           </table>
         </div>
       )}
@@ -41,13 +45,7 @@ function RankTable({
   );
 }
 
-function YearTable({
-  title,
-  rows,
-}: {
-  title: string;
-  rows: { year: number; count: number }[];
-}) {
+function YearTable({ title, rows }: { title: string; rows: { year: number; count: number }[] }) {
   return (
     <div style={{ marginBottom: "2rem" }}>
       <h3 className="app-page__section-title">{title}</h3>
@@ -56,20 +54,22 @@ function YearTable({
       ) : (
         <div className="app-table-wrap">
           <table className="app-table app-table--compact responsive-stack app-rank-table">
-          <thead>
-            <tr>
-              <th>Year</th>
-              <th className="is-right">Releases</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((row) => (
-              <tr key={row.year}>
-                <td data-label="Year">{row.year}</td>
-                <td data-label="Releases" className="is-right">{row.count}</td>
+            <thead>
+              <tr>
+                <th>Year</th>
+                <th className="is-right">Releases</th>
               </tr>
-            ))}
-          </tbody>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.year}>
+                  <td data-label="Year">{row.year}</td>
+                  <td data-label="Releases" className="is-right">
+                    {row.count}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
           </table>
         </div>
       )}
@@ -88,7 +88,7 @@ export function AnalyticsPage() {
     fetchAnalytics({ limit: 10 })
       .then((payload) => setData(payload.data))
       .catch((err: unknown) =>
-        setError(err instanceof Error ? err.message : "Failed to load analytics.")
+        setError(err instanceof Error ? err.message : "Failed to load analytics."),
       )
       .finally(() => setLoading(false));
   }, []);
@@ -113,11 +113,15 @@ export function AnalyticsPage() {
             </article>
             <article className="app-surface app-stat-card">
               <p className="app-stat-card__label">Mapped</p>
-              <p className="app-stat-card__value" style={{ color: "var(--success)" }}>{data.mapped_count}</p>
+              <p className="app-stat-card__value" style={{ color: "var(--success)" }}>
+                {data.mapped_count}
+              </p>
             </article>
             <article className="app-surface app-stat-card">
               <p className="app-stat-card__label">Unmatched</p>
-              <p className="app-stat-card__value" style={{ color: "#b8860b" }}>{data.unmatched_count}</p>
+              <p className="app-stat-card__value" style={{ color: "#b8860b" }}>
+                {data.unmatched_count}
+              </p>
             </article>
             {data.release_count_active > 0 ? (
               <article className="app-surface app-stat-card">

--- a/webapp/src/pages/CollectionPage.tsx
+++ b/webapp/src/pages/CollectionPage.tsx
@@ -21,12 +21,18 @@ type SyncState = "idle" | "syncing" | "done" | "error";
 function sortReleases(releases: Release[], sortKey: SortKey): Release[] {
   return [...releases].sort((a, b) => {
     switch (sortKey) {
-      case "artist_asc": return a.artist.localeCompare(b.artist);
-      case "artist_desc": return b.artist.localeCompare(a.artist);
-      case "title_asc": return a.title.localeCompare(b.title);
-      case "year_desc": return (Number(b.year) || 0) - (Number(a.year) || 0);
-      case "year_asc": return (Number(a.year) || 0) - (Number(b.year) || 0);
-      case "value_desc": return (b.value?.price_median ?? 0) - (a.value?.price_median ?? 0);
+      case "artist_asc":
+        return a.artist.localeCompare(b.artist);
+      case "artist_desc":
+        return b.artist.localeCompare(a.artist);
+      case "title_asc":
+        return a.title.localeCompare(b.title);
+      case "year_desc":
+        return (Number(b.year) || 0) - (Number(a.year) || 0);
+      case "year_asc":
+        return (Number(a.year) || 0) - (Number(b.year) || 0);
+      case "value_desc":
+        return (b.value?.price_median ?? 0) - (a.value?.price_median ?? 0);
     }
   });
 }
@@ -49,8 +55,8 @@ function parseFocusId(raw: string | null): number | null {
 
 function formatSyncSummary(summary: SyncSummary): string {
   return (
-    `Collection sync complete: fetched ${summary.fetched_count}, `
-    + `upserted ${summary.upserted_count}, deactivated ${summary.deactivated_count}.`
+    `Collection sync complete: fetched ${summary.fetched_count}, ` +
+    `upserted ${summary.upserted_count}, deactivated ${summary.deactivated_count}.`
   );
 }
 
@@ -143,22 +149,25 @@ export function CollectionPage() {
     const shouldValidateFocus = pendingFocusValidation;
     setLoading(true);
     setError("");
-    fetchReleases({
-      limit,
-      q: debouncedQuery || undefined,
-      year: debouncedYear || undefined,
-      genres: debouncedGenre ? [debouncedGenre] : undefined,
-      unmatched: unmatchedOnly || undefined,
-      withValue: showValue || undefined,
-    }, { signal: controller.signal })
+    fetchReleases(
+      {
+        limit,
+        q: debouncedQuery || undefined,
+        year: debouncedYear || undefined,
+        genres: debouncedGenre ? [debouncedGenre] : undefined,
+        unmatched: unmatchedOnly || undefined,
+        withValue: showValue || undefined,
+      },
+      { signal: controller.signal },
+    )
       .then((payload) => {
         if (cancelled) return;
         const nextReleases = payload.data ?? [];
         setReleases(nextReleases);
         if (
-          shouldValidateFocus
-          && focusedReleaseId != null
-          && !nextReleases.some((release) => release.discogs_release_id === focusedReleaseId)
+          shouldValidateFocus &&
+          focusedReleaseId != null &&
+          !nextReleases.some((release) => release.discogs_release_id === focusedReleaseId)
         ) {
           clearFocus();
         }
@@ -181,7 +190,16 @@ export function CollectionPage() {
       cancelled = true;
       controller.abort();
     };
-  }, [debouncedQuery, debouncedYear, debouncedGenre, unmatchedOnly, showValue, limit, reloadToken, pageVisible]);
+  }, [
+    debouncedQuery,
+    debouncedYear,
+    debouncedGenre,
+    unmatchedOnly,
+    showValue,
+    limit,
+    reloadToken,
+    pageVisible,
+  ]);
 
   useEffect(() => {
     if (!pageVisible) return;
@@ -189,12 +207,15 @@ export function CollectionPage() {
     const controller = new AbortController();
     setSummaryLoading(true);
     setSummaryError("");
-    fetchReleaseSummary({
-      q: debouncedQuery || undefined,
-      year: debouncedYear || undefined,
-      genres: debouncedGenre ? [debouncedGenre] : undefined,
-      unmatched: unmatchedOnly || undefined,
-    }, { signal: controller.signal })
+    fetchReleaseSummary(
+      {
+        q: debouncedQuery || undefined,
+        year: debouncedYear || undefined,
+        genres: debouncedGenre ? [debouncedGenre] : undefined,
+        unmatched: unmatchedOnly || undefined,
+      },
+      { signal: controller.signal },
+    )
       .then((payload) => {
         if (cancelled) return;
         setSummary(payload.data ?? null);
@@ -202,9 +223,7 @@ export function CollectionPage() {
       .catch((err: unknown) => {
         if (cancelled) return;
         if (err instanceof Error && err.name === "AbortError") return;
-        setSummaryError(
-          err instanceof Error ? err.message : "Failed to load collection summary.",
-        );
+        setSummaryError(err instanceof Error ? err.message : "Failed to load collection summary.");
       })
       .finally(() => {
         if (!cancelled) setSummaryLoading(false);
@@ -398,11 +417,19 @@ export function CollectionPage() {
         </div>
         <div className="app-toolbar__group">
           <label className="app-checkbox">
-            <input type="checkbox" checked={unmatchedOnly} onChange={(e) => setUnmatchedOnly(e.target.checked)} />
+            <input
+              type="checkbox"
+              checked={unmatchedOnly}
+              onChange={(e) => setUnmatchedOnly(e.target.checked)}
+            />
             Unmatched only
           </label>
           <label className="app-checkbox">
-            <input type="checkbox" checked={showValue} onChange={(e) => setShowValue(e.target.checked)} />
+            <input
+              type="checkbox"
+              checked={showValue}
+              onChange={(e) => setShowValue(e.target.checked)}
+            />
             Show value
           </label>
           <div className="app-toolbar__field">
@@ -428,7 +455,14 @@ export function CollectionPage() {
             onClick={handleSpin}
             disabled={spinning}
           >
-            {spinning ? <><span className="app-spinner" />Spinning…</> : "Spin"}
+            {spinning ? (
+              <>
+                <span className="app-spinner" />
+                Spinning…
+              </>
+            ) : (
+              "Spin"
+            )}
           </button>
           <button
             type="button"
@@ -442,7 +476,9 @@ export function CollectionPage() {
       </section>
 
       {syncMessage ? (
-        <p className={`app-message ${syncState === "error" ? "app-message--error" : "app-message--success"}`}>
+        <p
+          className={`app-message ${syncState === "error" ? "app-message--error" : "app-message--success"}`}
+        >
           {syncMessage}
         </p>
       ) : null}
@@ -452,8 +488,12 @@ export function CollectionPage() {
       {summaryLoading ? (
         <p className="app-message app-message--subtle">Loading collection summary…</p>
       ) : null}
-      {loading && releases.length === 0 ? <p className="app-message app-message--subtle">Loading releases…</p> : null}
-      {!loading && !error && releases.length === 0 ? <p className="app-message app-message--subtle">No releases found.</p> : null}
+      {loading && releases.length === 0 ? (
+        <p className="app-message app-message--subtle">Loading releases…</p>
+      ) : null}
+      {!loading && !error && releases.length === 0 ? (
+        <p className="app-message app-message--subtle">No releases found.</p>
+      ) : null}
 
       <ul className="app-record-list">
         {sorted.map((release) => {
@@ -476,7 +516,9 @@ export function CollectionPage() {
               <div className="app-record__header">
                 <p className="app-record__title">
                   <strong>{release.artist}</strong> — {release.title}
-                  {release.year ? <span className="app-record__year"> ({release.year})</span> : null}
+                  {release.year ? (
+                    <span className="app-record__year"> ({release.year})</span>
+                  ) : null}
                 </p>
                 {showValue && release.value?.price_median != null ? (
                   <span className="app-record__price">
@@ -487,7 +529,9 @@ export function CollectionPage() {
               {release.genres.length > 0 || release.styles.length > 0 ? (
                 <div className="app-tag-list" style={{ marginTop: "0.5rem" }}>
                   {[...release.genres, ...release.styles].slice(0, 3).map((tag) => (
-                    <span key={tag} className="app-tag" style={pillStyle}>{tag}</span>
+                    <span key={tag} className="app-tag" style={pillStyle}>
+                      {tag}
+                    </span>
                   ))}
                 </div>
               ) : null}

--- a/webapp/src/pages/HealthPage.tsx
+++ b/webapp/src/pages/HealthPage.tsx
@@ -17,7 +17,9 @@ export function HealthPage() {
     setError("");
     fetchCollectionHealth()
       .then((payload) => setHealth(payload.data))
-      .catch((err: unknown) => setError(err instanceof Error ? err.message : "Failed to load health data."))
+      .catch((err: unknown) =>
+        setError(err instanceof Error ? err.message : "Failed to load health data."),
+      )
       .finally(() => setLoading(false));
   }, []);
 
@@ -30,7 +32,9 @@ export function HealthPage() {
       </header>
 
       {error ? <p className="app-message app-message--error">{error}</p> : null}
-      {loading ? <p className="app-message app-message--subtle">Loading collection health…</p> : null}
+      {loading ? (
+        <p className="app-message app-message--subtle">Loading collection health…</p>
+      ) : null}
 
       {!loading && !error && health !== null ? (
         <>
@@ -38,7 +42,9 @@ export function HealthPage() {
             <p className="app-stat-card__label">Health score</p>
             <p className="app-stat-card__value" style={{ color: scoreColor(health.score) }}>
               {health.score}
-              <span style={{ fontSize: "1rem", color: "var(--muted)", marginLeft: "0.35rem" }}>/100</span>
+              <span style={{ fontSize: "1rem", color: "var(--muted)", marginLeft: "0.35rem" }}>
+                /100
+              </span>
             </p>
             <p className="app-stat-card__meta">{health.total_active} releases</p>
           </section>
@@ -58,8 +64,12 @@ export function HealthPage() {
                   {health.buckets.map((bucket) => (
                     <tr key={bucket.name}>
                       <td data-label="Label">{bucket.label}</td>
-                      <td data-label="Gap" className="is-right">{bucket.gap_count}</td>
-                      <td data-label="Percent" className="is-right">{bucket.gap_pct.toFixed(1)}%</td>
+                      <td data-label="Gap" className="is-right">
+                        {bucket.gap_count}
+                      </td>
+                      <td data-label="Percent" className="is-right">
+                        {bucket.gap_pct.toFixed(1)}%
+                      </td>
                       <td
                         data-label="Deduction"
                         className="is-right"

--- a/webapp/src/pages/HomePage.tsx
+++ b/webapp/src/pages/HomePage.tsx
@@ -30,8 +30,8 @@ type SyncState = "idle" | "syncing" | "done" | "error";
 
 function formatSyncSummary(label: "Collection" | "Wantlist", summary: SyncSummary): string {
   return (
-    `${label} sync complete: fetched ${summary.fetched_count}, `
-    + `upserted ${summary.upserted_count}, deactivated ${summary.deactivated_count}.`
+    `${label} sync complete: fetched ${summary.fetched_count}, ` +
+    `upserted ${summary.upserted_count}, deactivated ${summary.deactivated_count}.`
   );
 }
 
@@ -79,8 +79,12 @@ export function HomePage() {
         setStatus(statusPayload.data);
         setInsights(insightsPayload.data);
       })
-      .catch((err: unknown) => { if (!cancelled) setError(err instanceof Error ? err.message : "Unknown API error."); });
-    return () => { cancelled = true; };
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown API error.");
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   function handleSyncCollection() {
@@ -127,12 +131,15 @@ export function HomePage() {
         <div>
           <h1 className="app-page__title">Discogs Spinner</h1>
           <p className="app-page__subtitle">
-            Your records, your market. Browse your collection, spin something to play, and keep wantlist and value context close.
+            Your records, your market. Browse your collection, spin something to play, and keep
+            wantlist and value context close.
           </p>
         </div>
       </header>
       {error ? <p className="app-message app-message--error">{error}</p> : null}
-      {!error && !status ? <p className="app-message app-message--subtle">Loading status…</p> : null}
+      {!error && !status ? (
+        <p className="app-message app-message--subtle">Loading status…</p>
+      ) : null}
       {status ? (
         <section className="app-stat-grid">
           <article className="app-surface app-stat-card">
@@ -165,7 +172,9 @@ export function HomePage() {
                 {status.spotify_capability.action_label}
               </p>
               <p className="app-stat-card__meta">
-                {status.spotify_capability.addon_available ? "Addon installed" : "Addon unavailable"}
+                {status.spotify_capability.addon_available
+                  ? "Addon installed"
+                  : "Addon unavailable"}
               </p>
             </article>
           ) : null}
@@ -185,13 +194,19 @@ export function HomePage() {
       ) : null}
       {status?.provider_readiness ? (
         <section className="app-surface app-card" style={{ marginTop: "1.25rem" }}>
-          <h2 className="app-stack-label" style={{ marginBottom: "0.5rem" }}>Setup Guidance</h2>
+          <h2 className="app-stack-label" style={{ marginBottom: "0.5rem" }}>
+            Setup Guidance
+          </h2>
           {!status.provider_readiness.summary.required_services_configured ? (
             <div style={{ marginBottom: "1rem" }}>
               <p className="app-message app-message--error" style={{ marginBottom: "0.75rem" }}>
                 Discogs setup is required before you can browse your collection.
               </p>
-              <Link to="/setup" className="app-button app-button--primary" style={{ display: "inline-block" }}>
+              <Link
+                to="/setup"
+                className="app-button app-button--primary"
+                style={{ display: "inline-block" }}
+              >
                 Go to Setup
               </Link>
             </div>
@@ -208,7 +223,8 @@ export function HomePage() {
           <ul className="app-list">
             {status.provider_readiness.providers.map((provider) => (
               <li key={provider.provider_id}>
-                <strong>{provider.display_name}</strong>: {provider.readiness} — {provider.status_message}
+                <strong>{provider.display_name}</strong>: {provider.readiness} —{" "}
+                {provider.status_message}
               </li>
             ))}
           </ul>
@@ -228,9 +244,13 @@ export function HomePage() {
       ) : null}
       {insights ? (
         <section className="app-surface app-card" style={{ marginTop: "1.25rem" }}>
-          <h2 className="app-stack-label" style={{ marginBottom: "0.5rem" }}>Collector Insights</h2>
+          <h2 className="app-stack-label" style={{ marginBottom: "0.5rem" }}>
+            Collector Insights
+          </h2>
           <p className="app-message app-message--subtle" style={{ marginBottom: "0.75rem" }}>
-            Health {insights.summary.health_score}/100 · Hidden gems {insights.summary.hidden_gems_count} · Value queue {insights.summary.refresh_queue_count}
+            Health {insights.summary.health_score}/100 · Hidden gems{" "}
+            {insights.summary.hidden_gems_count} · Value queue{" "}
+            {insights.summary.refresh_queue_count}
           </p>
           {insights.highlights.length > 0 ? (
             <ul className="app-list">
@@ -241,7 +261,9 @@ export function HomePage() {
               ))}
             </ul>
           ) : (
-            <p className="app-message app-message--subtle">No urgent insights right now. Try a fresh sync or value refresh.</p>
+            <p className="app-message app-message--subtle">
+              No urgent insights right now. Try a fresh sync or value refresh.
+            </p>
           )}
           {insights.daily_use_actions.length > 0 ? (
             <>
@@ -277,12 +299,16 @@ export function HomePage() {
         </button>
       </div>
       {collectionMsg ? (
-        <p className={`app-message ${collectionSync === "error" ? "app-message--error" : "app-message--success"}`}>
+        <p
+          className={`app-message ${collectionSync === "error" ? "app-message--error" : "app-message--success"}`}
+        >
           {collectionMsg}
         </p>
       ) : null}
       {wantlistMsg ? (
-        <p className={`app-message ${wantlistSync === "error" ? "app-message--error" : "app-message--success"}`}>
+        <p
+          className={`app-message ${wantlistSync === "error" ? "app-message--error" : "app-message--success"}`}
+        >
           {wantlistMsg}
         </p>
       ) : null}

--- a/webapp/src/pages/RecentPage.tsx
+++ b/webapp/src/pages/RecentPage.tsx
@@ -44,7 +44,9 @@ export function RecentPage() {
           </p>
         </div>
         <div className="app-inline-actions">
-          <label className="app-stack-label" htmlFor="recent-days">Last</label>
+          <label className="app-stack-label" htmlFor="recent-days">
+            Last
+          </label>
           <select
             id="recent-days"
             className="app-select"
@@ -63,7 +65,9 @@ export function RecentPage() {
       {error ? <p className="app-message app-message--error">{error}</p> : null}
       {loading ? <p className="app-message app-message--subtle">Loading recent releases…</p> : null}
       {!loading && !error && releases.length === 0 ? (
-        <p className="app-message app-message--subtle">No releases added in the last {days} days.</p>
+        <p className="app-message app-message--subtle">
+          No releases added in the last {days} days.
+        </p>
       ) : null}
 
       <ul className="app-record-list">
@@ -72,11 +76,12 @@ export function RecentPage() {
             <div className="app-record__header">
               <p className="app-record__title">
                 <strong>{release.artist}</strong> — {release.title}
-                {release.year ? (
-                  <span className="app-record__year"> ({release.year})</span>
-                ) : null}
+                {release.year ? <span className="app-record__year"> ({release.year})</span> : null}
               </p>
-              <Link className="app-link-button app-link-button--ghost" to={`/collection?focus=${release.discogs_release_id}`}>
+              <Link
+                className="app-link-button app-link-button--ghost"
+                to={`/collection?focus=${release.discogs_release_id}`}
+              >
                 View in Collection
               </Link>
             </div>

--- a/webapp/src/pages/SetupPage.tsx
+++ b/webapp/src/pages/SetupPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getJson, postJson } from "../api";
+import { postJson } from "../api";
 
 type SetupResponse = {
   onboarding_stage: string;
@@ -13,19 +13,19 @@ function describeSetupError(err: unknown): string {
   const raw = err instanceof Error ? err.message : "";
   const lower = raw.toLowerCase();
   if (
-    lower.includes("token")
-    || lower.includes("auth")
-    || lower.includes("401")
-    || lower.includes("unauthorized")
+    lower.includes("token") ||
+    lower.includes("auth") ||
+    lower.includes("401") ||
+    lower.includes("unauthorized")
   ) {
     return "Token rejected — check your token at discogs.com/settings/developers.";
   }
   if (
-    lower.includes("network")
-    || lower.includes("connection")
-    || lower.includes("timeout")
-    || lower.includes("failed to fetch")
-    || lower.includes("fetch")
+    lower.includes("network") ||
+    lower.includes("connection") ||
+    lower.includes("timeout") ||
+    lower.includes("failed to fetch") ||
+    lower.includes("fetch")
   ) {
     return "Network error — check your internet connection and try again.";
   }
@@ -37,19 +37,6 @@ export function SetupPage() {
   const [token, setToken] = useState("");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
-  const [setupState, setSetupState] = useState<SetupResponse | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    getJson<SetupResponse>("/setup")
-      .then((payload) => {
-        if (!cancelled) setSetupState(payload.data);
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -68,41 +55,41 @@ export function SetupPage() {
   return (
     <main className="app-page app-page--narrow">
       <section className="app-surface app-card" style={{ marginTop: "2.5rem" }}>
-      <h1 className="app-page__title">Welcome to Discogs Spinner</h1>
-      <p className="app-page__subtitle" style={{ marginBottom: "1.25rem" }}>
-        Discogs setup is required. Playback providers are optional and can be connected later.
-      </p>
-      <p className="app-page__subtitle" style={{ marginBottom: "1.25rem" }}>
-        Enter your Discogs personal access token to continue. You can find it at{" "}
-        <a href="https://www.discogs.com/settings/developers" target="_blank" rel="noreferrer">
-          discogs.com/settings/developers
-        </a>
-        .
-      </p>
-      <form onSubmit={(e) => { void handleSubmit(e); }}>
-        <div style={{ marginBottom: "1rem" }}>
-          <label htmlFor="token" className="app-stack-label">
-            Discogs Token
-          </label>
-          <input
-            id="token"
-            type="password"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="your_personal_access_token"
-            required
-            className="app-input"
-          />
-        </div>
-        {error ? <p className="app-message app-message--error">{error}</p> : null}
-        <button
-          type="submit"
-          disabled={saving}
-          className="app-button app-button--primary"
+        <h1 className="app-page__title">Welcome to Discogs Spinner</h1>
+        <p className="app-page__subtitle" style={{ marginBottom: "1.25rem" }}>
+          Discogs setup is required. Playback providers are optional and can be connected later.
+        </p>
+        <p className="app-page__subtitle" style={{ marginBottom: "1.25rem" }}>
+          Enter your Discogs personal access token to continue. You can find it at{" "}
+          <a href="https://www.discogs.com/settings/developers" target="_blank" rel="noreferrer">
+            discogs.com/settings/developers
+          </a>
+          .
+        </p>
+        <form
+          onSubmit={(e) => {
+            void handleSubmit(e);
+          }}
         >
-          {saving ? "Saving…" : "Save Token"}
-        </button>
-      </form>
+          <div style={{ marginBottom: "1rem" }}>
+            <label htmlFor="token" className="app-stack-label">
+              Discogs Token
+            </label>
+            <input
+              id="token"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="your_personal_access_token"
+              required
+              className="app-input"
+            />
+          </div>
+          {error ? <p className="app-message app-message--error">{error}</p> : null}
+          <button type="submit" disabled={saving} className="app-button app-button--primary">
+            {saving ? "Saving…" : "Save Token"}
+          </button>
+        </form>
       </section>
     </main>
   );

--- a/webapp/src/pages/ValuePage.tsx
+++ b/webapp/src/pages/ValuePage.tsx
@@ -105,7 +105,8 @@ export function ValuePage() {
         <div>
           <h1 className="app-page__title">Collection Value</h1>
           <p className="app-page__subtitle">
-            Review price leaders and refresh candidates, then jump back into the collection with the target release focused.
+            Review price leaders and refresh candidates, then jump back into the collection with the
+            target release focused.
           </p>
         </div>
         <div className="app-inline-actions">
@@ -124,13 +125,17 @@ export function ValuePage() {
       </header>
 
       {refreshMsg ? (
-        <p className={`app-message ${refreshError ? "app-message--error" : "app-message--success"}`}>
+        <p
+          className={`app-message ${refreshError ? "app-message--error" : "app-message--success"}`}
+        >
           {refreshMsg}
         </p>
       ) : null}
 
       {error ? <p className="app-message app-message--error">{error}</p> : null}
-      {loading ? <p className="app-message app-message--subtle">Loading market value dashboard…</p> : null}
+      {loading ? (
+        <p className="app-message app-message--subtle">Loading market value dashboard…</p>
+      ) : null}
 
       {!loading && !error && !hasData ? (
         <p className="app-message app-message--subtle">Run a value refresh to see market prices.</p>
@@ -156,11 +161,18 @@ export function ValuePage() {
                   <tr key={release.discogs_release_id}>
                     <td data-label="Artist">{release.artist}</td>
                     <td data-label="Title">{release.title}</td>
-                    <td data-label="Median" className="is-right">{formatCurrency(release.price_median, release.currency)}</td>
-                    <td data-label="High" className="is-right">{formatCurrency(release.price_high, release.currency)}</td>
+                    <td data-label="Median" className="is-right">
+                      {formatCurrency(release.price_median, release.currency)}
+                    </td>
+                    <td data-label="High" className="is-right">
+                      {formatCurrency(release.price_high, release.currency)}
+                    </td>
                     <td data-label="Currency">{release.currency}</td>
                     <td data-label="Action">
-                      <Link className="app-link-button app-link-button--ghost" to={`/collection?focus=${release.discogs_release_id}`}>
+                      <Link
+                        className="app-link-button app-link-button--ghost"
+                        to={`/collection?focus=${release.discogs_release_id}`}
+                      >
                         View in Collection
                       </Link>
                     </td>
@@ -178,7 +190,8 @@ export function ValuePage() {
             <div>
               <h2 className="app-page__section-title">Hidden Gems</h2>
               <p className="app-page__subtitle">
-                Owned releases that are quietly valuable AND hard to find on the Discogs marketplace right now.
+                Owned releases that are quietly valuable AND hard to find on the Discogs marketplace
+                right now.
               </p>
             </div>
           </div>
@@ -246,9 +259,15 @@ export function ValuePage() {
         {queue !== null && queue.total_candidates > 0 ? (
           <>
             <div className="app-inline-summary" style={{ marginBottom: "1rem" }}>
-              <span className="app-muted">Missing <strong>{queue.missing_count}</strong></span>
-              <span className="app-muted">Unpriced <strong>{queue.unpriced_count}</strong></span>
-              <span className="app-muted">Stale (&gt;{queue.stale_days}d) <strong>{queue.stale_count}</strong></span>
+              <span className="app-muted">
+                Missing <strong>{queue.missing_count}</strong>
+              </span>
+              <span className="app-muted">
+                Unpriced <strong>{queue.unpriced_count}</strong>
+              </span>
+              <span className="app-muted">
+                Stale (&gt;{queue.stale_days}d) <strong>{queue.stale_count}</strong>
+              </span>
             </div>
             <div className="app-table-wrap">
               <table className="app-table app-table--compact responsive-stack">
@@ -267,9 +286,14 @@ export function ValuePage() {
                       <td data-label="Artist">{item.artist}</td>
                       <td data-label="Title">{item.title}</td>
                       <td data-label="Reason">{item.market_need_reason}</td>
-                      <td data-label="Median" className="is-right">{item.market_median != null ? item.market_median.toFixed(2) : "—"}</td>
+                      <td data-label="Median" className="is-right">
+                        {item.market_median != null ? item.market_median.toFixed(2) : "—"}
+                      </td>
                       <td data-label="Action">
-                        <Link className="app-link-button app-link-button--ghost" to={`/collection?focus=${item.discogs_release_id}`}>
+                        <Link
+                          className="app-link-button app-link-button--ghost"
+                          to={`/collection?focus=${item.discogs_release_id}`}
+                        >
                           View in Collection
                         </Link>
                       </td>

--- a/webapp/src/pages/WantlistPage.tsx
+++ b/webapp/src/pages/WantlistPage.tsx
@@ -12,12 +12,18 @@ type SyncState = "idle" | "syncing" | "done" | "error";
 function sortReleases(releases: Release[], sortKey: SortKey): Release[] {
   return [...releases].sort((a, b) => {
     switch (sortKey) {
-      case "artist_asc": return a.artist.localeCompare(b.artist);
-      case "artist_desc": return b.artist.localeCompare(a.artist);
-      case "title_asc": return a.title.localeCompare(b.title);
-      case "year_desc": return (Number(b.year) || 0) - (Number(a.year) || 0);
-      case "year_asc": return (Number(a.year) || 0) - (Number(b.year) || 0);
-      case "value_desc": return (b.value?.price_median ?? 0) - (a.value?.price_median ?? 0);
+      case "artist_asc":
+        return a.artist.localeCompare(b.artist);
+      case "artist_desc":
+        return b.artist.localeCompare(a.artist);
+      case "title_asc":
+        return a.title.localeCompare(b.title);
+      case "year_desc":
+        return (Number(b.year) || 0) - (Number(a.year) || 0);
+      case "year_asc":
+        return (Number(a.year) || 0) - (Number(b.year) || 0);
+      case "value_desc":
+        return (b.value?.price_median ?? 0) - (a.value?.price_median ?? 0);
     }
   });
 }
@@ -34,8 +40,8 @@ function parseFocusId(raw: string | null): number | null {
 
 function formatSyncSummary(summary: SyncSummary): string {
   return (
-    `Wantlist sync complete: fetched ${summary.fetched_count}, `
-    + `upserted ${summary.upserted_count}, deactivated ${summary.deactivated_count}.`
+    `Wantlist sync complete: fetched ${summary.fetched_count}, ` +
+    `upserted ${summary.upserted_count}, deactivated ${summary.deactivated_count}.`
   );
 }
 
@@ -89,21 +95,24 @@ export function WantlistPage() {
     const shouldValidateFocus = pendingFocusValidation;
     setLoading(true);
     setError("");
-    fetchWantlist({
-      limit,
-      q: debouncedQuery || undefined,
-      year: debouncedYear || undefined,
-      genres: debouncedGenre ? [debouncedGenre] : undefined,
-      withValue: showValue || undefined,
-    }, { signal: controller.signal })
+    fetchWantlist(
+      {
+        limit,
+        q: debouncedQuery || undefined,
+        year: debouncedYear || undefined,
+        genres: debouncedGenre ? [debouncedGenre] : undefined,
+        withValue: showValue || undefined,
+      },
+      { signal: controller.signal },
+    )
       .then((payload) => {
         if (cancelled) return;
         const nextEntries = payload.data ?? [];
         setEntries(nextEntries);
         if (
-          shouldValidateFocus
-          && focusedReleaseId != null
-          && !nextEntries.some((entry) => entry.discogs_release_id === focusedReleaseId)
+          shouldValidateFocus &&
+          focusedReleaseId != null &&
+          !nextEntries.some((entry) => entry.discogs_release_id === focusedReleaseId)
         ) {
           clearFocus();
         }
@@ -244,7 +253,11 @@ export function WantlistPage() {
         </div>
         <div className="app-toolbar__group">
           <label className="app-checkbox">
-            <input type="checkbox" checked={showValue} onChange={(e) => setShowValue(e.target.checked)} />
+            <input
+              type="checkbox"
+              checked={showValue}
+              onChange={(e) => setShowValue(e.target.checked)}
+            />
             Show value
           </label>
           <div className="app-toolbar__field">
@@ -270,7 +283,14 @@ export function WantlistPage() {
             onClick={handleSpin}
             disabled={spinning}
           >
-            {spinning ? <><span className="app-spinner" />Spinning…</> : "Spin"}
+            {spinning ? (
+              <>
+                <span className="app-spinner" />
+                Spinning…
+              </>
+            ) : (
+              "Spin"
+            )}
           </button>
           <button
             type="button"
@@ -284,14 +304,20 @@ export function WantlistPage() {
       </section>
 
       {syncMessage ? (
-        <p className={`app-message ${syncState === "error" ? "app-message--error" : "app-message--success"}`}>
+        <p
+          className={`app-message ${syncState === "error" ? "app-message--error" : "app-message--success"}`}
+        >
           {syncMessage}
         </p>
       ) : null}
       {spinError ? <p className="app-message app-message--error">{spinError}</p> : null}
       {error ? <p className="app-message app-message--error">{error}</p> : null}
-      {loading && entries.length === 0 ? <p className="app-message app-message--subtle">Loading wantlist…</p> : null}
-      {!loading && !error && entries.length === 0 ? <p className="app-message app-message--subtle">No wantlist entries found.</p> : null}
+      {loading && entries.length === 0 ? (
+        <p className="app-message app-message--subtle">Loading wantlist…</p>
+      ) : null}
+      {!loading && !error && entries.length === 0 ? (
+        <p className="app-message app-message--subtle">No wantlist entries found.</p>
+      ) : null}
 
       <ul className="app-record-list">
         {sorted.map((entry) => {
@@ -324,7 +350,9 @@ export function WantlistPage() {
               {entry.genres.length > 0 || entry.styles.length > 0 ? (
                 <div className="app-tag-list" style={{ marginTop: "0.5rem" }}>
                   {[...entry.genres, ...entry.styles].slice(0, 3).map((tag) => (
-                    <span key={tag} className="app-tag" style={pillStyle}>{tag}</span>
+                    <span key={tag} className="app-tag" style={pillStyle}>
+                      {tag}
+                    </span>
                   ))}
                 </div>
               ) : null}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -56,7 +56,10 @@ button,
   color: var(--text);
   padding: 0.6rem 1rem;
   cursor: pointer;
-  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease,
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease,
     transform 140ms ease;
 }
 
@@ -126,11 +129,7 @@ button:disabled,
   z-index: 10;
   padding: 1rem 1.25rem 0.8rem;
   backdrop-filter: blur(10px);
-  background: linear-gradient(
-    180deg,
-    rgba(244, 240, 232, 0.95),
-    rgba(244, 240, 232, 0.82)
-  );
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.95), rgba(244, 240, 232, 0.82));
   border-bottom: 1px solid rgba(88, 67, 39, 0.08);
 }
 
@@ -151,7 +150,10 @@ button:disabled,
   color: var(--muted);
   background: rgba(255, 255, 255, 0.42);
   border: 1px solid transparent;
-  transition: color 140ms ease, background 140ms ease, border-color 140ms ease,
+  transition:
+    color 140ms ease,
+    background 140ms ease,
+    border-color 140ms ease,
     transform 140ms ease;
 }
 
@@ -381,7 +383,10 @@ button:disabled,
 
 .app-record--interactive {
   cursor: pointer;
-  transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
 }
 
 .app-record--interactive:hover {
@@ -440,9 +445,15 @@ button:disabled,
 }
 
 @keyframes spin-reveal {
-  0%   { box-shadow: 0 0 0 0 rgba(12, 93, 124, 0.45); }
-  60%  { box-shadow: 0 0 0 14px rgba(12, 93, 124, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(12, 93, 124, 0); }
+  0% {
+    box-shadow: 0 0 0 0 rgba(12, 93, 124, 0.45);
+  }
+  60% {
+    box-shadow: 0 0 0 14px rgba(12, 93, 124, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(12, 93, 124, 0);
+  }
 }
 
 .app-focus-card--spin-result {
@@ -450,7 +461,9 @@ button:disabled,
 }
 
 @keyframes spin-rotate {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .app-spinner {

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -4,6 +4,6 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
-  }
+    port: 5173,
+  },
 });


### PR DESCRIPTION
## Summary

The two deferred items from the repo-review round (Q2 + Q3). Both linters were configured/possible but never run in CI; turning them on surfaced **real bugs**, not just style nits.

### Q2 — Enforce ruff + mypy (Python)
- New `lint` job runs `ruff check .` + `mypy src`. Added a `lint` optional-dependency group (ruff, mypy, pinned) and install `.[lint,spotify,web]` so mypy resolves third-party imports.
- **ruff** was already clean.
- **mypy** surfaced 8 real type errors, all fixed:
  - 5 "object is not iterable" + 1 `len(object)` in widgets/`main_window` — narrowed `dict.get()` results with `isinstance(..., list)`.
  - 2 in `/share/.../markdown` API routes — **a latent runtime bug**: both endpoints declared `-> str` but returned `run_use_case()`'s dict envelope, so they **500'd with `ResponseValidationError` on every request** (verified via TestClient). Added `run_use_case_raw()` so the `PlainTextResponse` endpoints serve the markdown as intended, plus **regression tests** (they had zero coverage).
- Fixed a workflow inconsistency: the merged `test-full` job referenced `${{ env.PYTHON_VERSION }}` which `main` never defined (it ran on an *unpinned* Python). Defined `PYTHON_VERSION` and used it across all jobs.

### Q3 — Webapp eslint + prettier + typecheck
- Added `eslint.config.js` (flat config), `.prettierrc.json`, `.prettierignore`, npm `lint`/`typecheck`/`format`/`format:check` scripts, and a `webapp-lint` CI job (eslint + `tsc --noEmit` + `prettier --check`). `tsconfig` was already `strict`.
- **`tsc --noEmit`** caught 3 type errors the Vite build silently ignores — `RankTable` required an index signature the typed rows lacked; made it generic over the row type.
- **ESLint** caught dead state in `SetupPage` (an unused `/setup` pre-fetch already covered by `App.tsx`) — removed it.
- The remaining 3 `react-hooks/exhaustive-deps` are pre-existing intentional focus/once effects; the gate fails on **errors**, not warnings (matching the codebase's existing tolerance).

## Test plan
- [x] `ruff check .` clean · `mypy src` clean (136 files)
- [x] Full Python suite: **705 passed, 3 skipped** (incl. 2 new share regression tests)
- [x] webapp `npm run lint` / `typecheck` / `format:check` / `build` all pass
- [x] `npm ci` in sync with committed lockfile · `core_plus_ci.yml` valid YAML
- [x] `test_core_plus_ci_workflow.py` still passes with the new jobs

## Review note
Most of the webapp file diff is the one-time `prettier --write` normalization. The substantive changes are: the two type/lint fixes above, the eslint/prettier configs, the npm scripts, and the two new CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_