### PR TITLE
docs: v1.0 release-prep — flow index, tracker refresh, SIGNING reconcile

### DIFF
--- a/docs/RC_RELEASE_RUNBOOK.md
+++ b/docs/RC_RELEASE_RUNBOOK.md
@@ -1,5 +1,12 @@
 # RC Release Runbook (`v0.2.0-rc1` and later)
 
+> **⚠️ Deprecated.** This runbook describes the legacy **tarball-based** release
+> candidate process driven by `tagged_release.yml`. The current release path
+> builds native installers via `installer_build.yml` — use
+> **[PUBLIC_RELEASE_RUNBOOK.md](PUBLIC_RELEASE_RUNBOOK.md)** to cut a release and
+> **[V1_RELEASE_FLOW.md](V1_RELEASE_FLOW.md)** for the end-to-end v1.0 sequence.
+> Kept for historical reference only.
+
 Owner: Engineering  
 Date created: 2026-02-26
 

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,63 +1,67 @@
-# Code Signing Checklist
+# Code Signing
 
-This document covers signing for macOS, Windows, and Debian distributions of Discogs Spinner.
-Signing was optional for the pilot / `v0.2.0` release line. For the recommended `v1.0.0` bar, Windows signing and macOS signing/notarization should be treated as release requirements.
+Signing for macOS, Windows, and Debian distributions of Discogs Spinner.
+Signing was optional for the pilot / `v0.2.0` line. For the `v1.0.0` bar, Windows
+signing and macOS signing + notarization are release requirements (see
+`docs/RELEASE_TARGET_v1.0.md`).
+
+## How it's already wired
+
+**`installer_build.yml` is already set up to sign — there is no workflow code to
+uncomment or change.** Its "Configure optional code-signing env" step reads the
+signing secrets and exports each one to `$GITHUB_ENV` *only when it is non-empty*.
+When the secrets are unset, the vars stay truly absent and Tauri produces clean
+**unsigned** bundles; when they're set, the macOS keychain-import step runs and
+Tauri signs (and, for macOS, notarizes). So enabling signing is entirely a matter
+of **adding the GitHub Actions secrets below and re-running a tagged build** —
+`tauri.conf.json` can keep `signingIdentity: null` because CI drives it via env.
+
+Add secrets under **Settings → Secrets and variables → Actions → New repository
+secret**, then push a `v*` tag (or re-run `installer_build.yml`).
 
 ---
 
 ## macOS
 
-**Requirement:** Apple Developer Program membership (~$99/yr at developer.apple.com)
+**Requires:** Apple Developer Program membership (~$99/yr).
 
-### Certificates
+### Secrets (exact names consumed by CI)
 
-1. Open Xcode → Settings → Accounts → Manage Certificates → create a "Developer ID Application" cert.
-2. Export the `.p12` from Keychain Access (File → Export Items), set a strong password.
-3. Base64-encode the file:
+| Secret | Value |
+|---|---|
+| `APPLE_CERTIFICATE` | base64 of the exported Developer ID Application `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | password set when exporting the `.p12` |
+| `APPLE_SIGNING_IDENTITY` | the identity string, e.g. `Developer ID Application: Eric Donahue (XXXXXXXXXX)` |
+| `APPLE_ID` | your Apple ID email |
+| `APPLE_TEAM_ID` | 10-character team ID (developer.apple.com → Membership) |
+| `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password (appleid.apple.com → Sign-In & Security) |
+
+### Steps
+
+1. In Xcode → Settings → Accounts → Manage Certificates, create a **Developer ID
+   Application** certificate.
+2. In Keychain Access, find that certificate and **File → Export Items** as a
+   password-protected `.p12`.
+3. Get the exact identity string for `APPLE_SIGNING_IDENTITY`:
    ```bash
-   base64 -i certificate.p12 | pbcopy
+   security find-identity -v -p codesigning
+   # → "Developer ID Application: Eric Donahue (XXXXXXXXXX)"
    ```
-4. Add GitHub secrets (Settings → Secrets and variables → Actions):
-   - `APPLE_CERTIFICATE_BASE64` — base64-encoded `.p12`
-   - `APPLE_CERTIFICATE_PASSWORD` — password you set on export
-   - `APPLE_ID` — your Apple ID email
-   - `APPLE_TEAM_ID` — 10-character team ID (visible in developer.apple.com → Membership)
-   - `APPLE_ID_PASSWORD` — app-specific password (appleid.apple.com → Sign-In & Security → App-Specific Passwords)
+4. Base64-encode the `.p12` for `APPLE_CERTIFICATE`:
+   ```bash
+   base64 -i certificate.p12 | pbcopy   # macOS, copies to clipboard
+   ```
+5. Add all six secrets above. CI imports the cert into a temporary keychain and
+   Tauri runs `xcrun notarytool submit` + `xcrun stapler staple` automatically.
 
-### Tauri configuration
+### Verify a signed + notarized build
 
-In `desktop_shell/src-tauri/tauri.conf.json`, the `bundle.macOS` section should reference:
-
-```json
-"macOS": {
-  "signingIdentity": "Developer ID Application: Your Name (TEAMID)",
-  "notarizationCredentials": {
-    "appleId": "your@apple.id",
-    "appleIdPassword": { "appleIdPassword": "xxxx-xxxx-xxxx-xxxx" },
-    "teamId": "XXXXXXXXXX"
-  }
-}
+```bash
+spctl --assess --type install --verbose=4 "/Applications/Discogs Spinner.app"   # → "accepted ... source=Notarized Developer ID"
+codesign --verify --deep --strict --verbose=2 "/Applications/Discogs Spinner.app"
 ```
 
-Tauri handles `xcrun notarytool submit` and `xcrun stapler staple` automatically when these values are set.
-
-### CI integration
-
-Uncomment the following env vars in the Tauri build step of `installer_build.yml`:
-
-```yaml
-env:
-  APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-  APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-  APPLE_SIGNING_IDENTITY: "Developer ID Application: Your Name (TEAMID)"
-  APPLE_ID: ${{ secrets.APPLE_ID }}
-  APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-  APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-```
-
-### Unsigned workaround for pilot users
-
-Until signing is activated, macOS users can bypass Gatekeeper with:
+### Unsigned workaround (until signing is on)
 
 ```bash
 xattr -dr com.apple.quarantine "/Applications/Discogs Spinner.app"
@@ -67,93 +71,82 @@ xattr -dr com.apple.quarantine "/Applications/Discogs Spinner.app"
 
 ## Windows
 
-### Option A: Unsigned (current `v0.2.0` posture)
+### Choosing a certificate path
 
-The NSIS installer produced by `cargo tauri build` works without a cert. Users will see a
-SmartScreen "Unknown publisher" warning. They click **More info → Run anyway** to proceed.
+`installer_build.yml` consumes `WINDOWS_CERTIFICATE` (base64 `.pfx`) and
+`WINDOWS_CERTIFICATE_PASSWORD`. The open question is *which kind of certificate* —
+the trade-offs:
 
-This is acceptable for the current stable line, but should not be the default experience for `v1.0.0`.
+| Option | SmartScreen | Cost / yr | Notes |
+|---|---|---|---|
+| **Unsigned** (current) | "Unknown publisher" warning; user clicks **More info → Run anyway** | $0 | Fine for `0.x`; not the `1.0` default experience |
+| **OV** (Organization Validation) | Warning persists until the binary builds download "reputation," then clears | ~$200–400 | Cheapest signed path; reputation can take weeks/many installs |
+| **EV** (Extended Validation) | Cleared **immediately** (no reputation wait) | ~$250–500 + hardware token / HSM | Strongest trust; requires a FIPS token or cloud HSM, more identity vetting |
+| **Azure Trusted Signing** | Cleared quickly (Microsoft-run) | ~$10/mo | Modern managed option; needs a verified Azure account + an eligible org/individual identity |
 
-### Option B: EV Code Signing Certificate (future)
+**Recommendation for this project:** since `1.0` is being approached gradually and
+the cost/instant-trust trade-off is the deciding factor, the pragmatic order is
+**Azure Trusted Signing** (cheapest path to fast SmartScreen trust if you can pass
+its identity verification) → **EV** (if you want a classic cert and accept the
+token) → **OV** (only if EV/Azure are unavailable; accept the reputation lag). Stay
+**unsigned** for any pre-`1.0` build — just keep the SmartScreen "Run anyway"
+workaround documented in the Windows quickstart. Revisit once a path is chosen;
+this doc currently lays out options rather than committing to one.
 
-EV certificates eliminate SmartScreen warnings and are required for Windows kernel drivers.
+### Secrets (once a `.pfx` is in hand)
 
-1. Obtain a certificate from DigiCert or Sectigo (~$300–500/yr for OV; EV requires extra identity verification).
-2. Export as a password-protected `.pfx` file, then base64-encode:
-   ```bash
-   base64 -i certificate.pfx
-   ```
-3. Add GitHub secrets:
-   - `TAURI_SIGNING_PRIVATE_KEY` — base64-encoded `.pfx`
-   - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — password
+| Secret | Value |
+|---|---|
+| `WINDOWS_CERTIFICATE` | base64 of the password-protected `.pfx` |
+| `WINDOWS_CERTIFICATE_PASSWORD` | the `.pfx` password |
 
-### CI integration (Windows)
-
-Uncomment in `installer_build.yml`:
-
-```yaml
-env:
-  TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-  TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+```bash
+base64 -w0 certificate.pfx   # Linux; on macOS use `base64 -i certificate.pfx`
 ```
+
+### Verify a signed installer
+
+```powershell
+Get-AuthenticodeSignature ".\Discogs.Spinner_x.y.z_x64-setup.exe" | Format-List
+# Status should be "Valid"; or: signtool verify /pa /v <installer>.exe
+```
+
+> **Not the same as updater signing.** `TAURI_SIGNING_PRIVATE_KEY` /
+> `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` are the **minisign** keys Tauri's updater
+> uses to sign `latest.json`/`.sig` artifacts — they are unrelated to Authenticode
+> code signing and do **not** remove SmartScreen warnings.
 
 ---
 
 ## Debian / Linux
 
-**Cost:** $0 — GPG signing only.
-
-### Sign a `.deb` with dpkg-sig
+**Cost:** $0 — GPG signing only; an unsigned `.deb` installs fine and is not a
+`1.0` blocker.
 
 ```bash
-# Install dpkg-sig if needed
 sudo apt install dpkg-sig
-
-# Sign the package
-dpkg-sig --sign builder discogs-spinner_0.2.0_amd64.deb
-
-# Verify
-dpkg-sig --verify discogs-spinner_0.2.0_amd64.deb
+dpkg-sig --sign builder discogs-spinner-gtk4_<version>_amd64.deb
+dpkg-sig --verify discogs-spinner-gtk4_<version>_amd64.deb
 ```
 
-### Distribute your public key
-
-Publish your GPG public key so users can verify:
+Distribute the public key so users can verify:
 
 ```bash
 gpg --export --armor YOUR_KEY_ID > discogs-spinner-pubkey.asc
-```
-
-Users add it:
-
-```bash
+# user side:
 sudo gpg --dearmor -o /usr/share/keyrings/discogs-spinner.gpg < discogs-spinner-pubkey.asc
 ```
 
-### Unsigned `.deb` for current release line
-
-An unsigned `.deb` installs fine via:
-
-```bash
-sudo dpkg -i discogs-spinner_0.2.0_amd64.deb
-```
-
-No blocker for the current public release line.
-
 ---
 
-## Adding Secrets to GitHub
+## Status / next steps
 
-1. Navigate to the repository on GitHub.
-2. Go to **Settings → Secrets and variables → Actions**.
-3. Click **New repository secret** for each secret listed above.
-4. After adding secrets, re-run the `installer_build.yml` workflow to produce signed artifacts.
-
----
-
-## macOS Signing/Notarization TODOs
-
-1. Define signing identity and certificate storage policy for CI.
-2. Add a codesign step for macOS release artifacts in tagged-release workflow.
-3. Add notarization submission + staple workflow and failure handling.
-4. Publish user-facing Gatekeeper troubleshooting section once signed builds ship.
+- ✅ CI is wired to consume all signing secrets (`installer_build.yml`); unsigned
+  by default, signed when secrets are present.
+- ⬜ **macOS:** enroll in Apple Developer Program, add the six `APPLE_*` secrets,
+  tag a build, verify with `spctl --assess`.
+- ⬜ **Windows:** choose a certificate path (see matrix above), add the two
+  `WINDOWS_CERTIFICATE*` secrets, verify with `Get-AuthenticodeSignature`.
+- ⬜ Once signed builds ship, add a user-facing Gatekeeper/SmartScreen
+  troubleshooting note to the OS quickstarts and flip the two signing gates in
+  `docs/V1_READINESS_TRACKER.md` to done.

--- a/docs/V1_READINESS_TRACKER.md
+++ b/docs/V1_READINESS_TRACKER.md
@@ -7,11 +7,17 @@ Purpose: operational tracker for the aspirational `v1.0.0` release target
 This file is the execution companion to `docs/RELEASE_TARGET_v1.0.md`.
 If a gate below remains open, continue shipping `0.x` releases.
 
+For the end-to-end ordered path (which doc to use at each step), see
+**`docs/V1_RELEASE_FLOW.md`**. The per-OS validation gate lives in
+**`docs/RELEASE_CHECKLIST_WINDOWS_DEBIAN_MACOS.md`**.
+
 ## Current Position
 
 - Product contract for `1.0` is now defined.
 - Support matrix for first-class vs secondary surfaces is now defined.
 - `v0.2.0` proved cross-platform installer buildability and release publication.
+- CI now enforces lint, type checking, the full Python test suite, and webapp
+  lint/type/tests on every push (closed below).
 - Remaining `1.0` work is mostly trust, FTUX, and supportability rather than new feature breadth.
 
 ## Gate Tracker
@@ -20,14 +26,16 @@ If a gate below remains open, continue shipping `0.x` releases.
 |---|---|---|
 | 1.0 product contract documented | done | `docs/RELEASE_TARGET_v1.0.md`, `PRODUCT_STATE.md` |
 | Support matrix documented | done | `docs/SUPPORT_MATRIX.md` |
-| Windows signing wired and verified | open | See `docs/SIGNING.md`; requires cert + CI secrets |
-| macOS signing + notarization wired and verified | open | See `docs/SIGNING.md`; requires Apple Developer credentials |
+| CI quality gates (lint, type check, full test suite) | done | `.github/workflows/core_plus_ci.yml` — `lint` (ruff + mypy), `test-full`, and `webapp-lint` (eslint + tsc + prettier + vitest) jobs; added in PRs #26, #29, #31 |
+| Signing CI wiring exists | done | `installer_build.yml` "Configure optional code-signing env" + keychain import steps consume the signing secrets; builds unsigned without them, signed with them |
+| Windows signing secrets set + signed build verified | open | Set `WINDOWS_CERTIFICATE*` secrets per `docs/SIGNING.md`, then verify a signed `-setup.exe` |
+| macOS signing + notarization secrets set + verified | open | Set `APPLE_*` secrets per `docs/SIGNING.md` (requires Apple Developer Program); verify with `spctl --assess` |
 | Windows clean-machine FTUX recorded | open | Use `docs/validation/windows_tauri_ftux.md` |
 | macOS clean-machine FTUX recorded | open | Use `docs/validation/macos_installer_ftux.md` |
 | Debian clean-machine FTUX recorded | open | Use `docs/validation/debian_installer_ftux.md` |
 | Live timing baseline recorded | open | Record in `docs/STABILIZATION_EXECUTION_2026Q1.md` via `dplayer-gui --timing` |
-| Small friend/beta cohort reviewed | open | Use `docs/friend_trial.md` and record top friction items here |
-| RC automation and manual gates green | open | `1.0.0-rc1` should only ship after the above gates close |
+| Small friend/beta cohort reviewed | open | Use `docs/friend_trial.md`; log friction in the table below |
+| RC automation and manual gates green | open | `1.0.0-rc1` should only ship after the above gates close; cut via `docs/PUBLIC_RELEASE_RUNBOOK.md` |
 
 ## Required Evidence Before `1.0.0-rc1`
 
@@ -39,6 +47,16 @@ If a gate below remains open, continue shipping `0.x` releases.
    - Debian/Ubuntu
 4. One live timing run recorded with browse-load and wantlist-load latencies.
 5. Friend-trial feedback reviewed; any P0/P1 install/setup blockers closed or explicitly accepted.
+
+## Friend-Trial Friction Log
+
+Record top friction items from the friend/beta cohort here (see `docs/friend_trial.md`).
+Severity: P0 = blocks install/setup, P1 = major friction, P2 = polish. Resolution:
+fixed (PR/issue link), accepted (known limitation), or open.
+
+| Date | OS | Reporter | Friction item | Severity | Resolution |
+|---|---|---|---|---|---|
+| _(none recorded yet)_ | | | | | |
 
 ## Open Questions To Close In This Tracker
 

--- a/docs/V1_RELEASE_FLOW.md
+++ b/docs/V1_RELEASE_FLOW.md
@@ -1,0 +1,66 @@
+# v1.0 Release Flow
+
+The single entry point for cutting `v1.0.0`. The v1.0 docs are otherwise spread
+across several files; this is the ordered path that chains them together. Each
+step links to the authoritative doc for that step — this index stays short on
+purpose and does not duplicate their content.
+
+> Status: aspirational target. Keep shipping `0.x` releases until every gate
+> below is green. Live gate status lives in **[V1_READINESS_TRACKER.md](V1_READINESS_TRACKER.md)**.
+
+## The path
+
+1. **Know what 1.0 means.** Read the promise, required gates, and explicit
+   non-goals in **[RELEASE_TARGET_v1.0.md](RELEASE_TARGET_v1.0.md)**.
+
+2. **Check gate status.** **[V1_READINESS_TRACKER.md](V1_READINESS_TRACKER.md)**
+   is the live checklist — it lists every gate, whether it's done/open, and where
+   the evidence lives. Work the open gates below; don't tag until all are closed.
+
+3. **Stand up signing trust.** Follow **[SIGNING.md](SIGNING.md)** to add the
+   GitHub signing secrets. `installer_build.yml` is already wired to consume them
+   (it builds unsigned when they're absent, signed when present), so this gate is
+   "set the secrets + verify a signed artifact" — no workflow code changes.
+
+4. **Capture a timing baseline.** Run `dplayer-gui --timing` against a real
+   collection once and record browse/wantlist latencies in
+   **[STABILIZATION_EXECUTION_2026Q1.md](STABILIZATION_EXECUTION_2026Q1.md)**
+   (Baseline Measurements table).
+
+5. **Run clean-machine FTUX on each OS.** Use the per-OS gate checklist in
+   **[RELEASE_CHECKLIST_WINDOWS_DEBIAN_MACOS.md](RELEASE_CHECKLIST_WINDOWS_DEBIAN_MACOS.md)**,
+   filling in the matching validation record:
+   - Windows → [validation/windows_tauri_ftux.md](validation/windows_tauri_ftux.md)
+   - macOS → [validation/macos_installer_ftux.md](validation/macos_installer_ftux.md)
+   - Debian → [validation/debian_installer_ftux.md](validation/debian_installer_ftux.md)
+
+6. **Run the friend/beta trial.** Hand the cohort
+   **[friend_trial.md](friend_trial.md)** (or the short
+   **[friend_trial_checklist.md](friend_trial_checklist.md)**); log friction in the
+   tracker's friend-trial table and close or explicitly accept P0/P1 items.
+
+7. **Cut the release.** Once the tracker is all-green, follow
+   **[PUBLIC_RELEASE_RUNBOOK.md](PUBLIC_RELEASE_RUNBOOK.md)** to tag and publish via
+   `installer_build.yml`. (The older tarball-based `RC_RELEASE_RUNBOOK.md` is
+   deprecated — see its banner.)
+
+8. **Push to stores.** After the GitHub Release publishes, work the channels in
+   **[STORE_SUBMISSIONS.md](STORE_SUBMISSIONS.md)** (its Submission Readiness
+   Snapshot lists each channel's next blocker).
+
+## At a glance
+
+| # | Step | Gate it closes | Authoritative doc |
+|---|------|----------------|-------------------|
+| 1 | Define 1.0 | product contract | RELEASE_TARGET_v1.0.md |
+| 2 | Track gates | — (the tracker) | V1_READINESS_TRACKER.md |
+| 3 | Signing | Windows + macOS signing | SIGNING.md |
+| 4 | Timing | live timing baseline | STABILIZATION_EXECUTION_2026Q1.md |
+| 5 | FTUX ×3 | clean-machine FTUX | RELEASE_CHECKLIST_WINDOWS_DEBIAN_MACOS.md + validation/*_ftux.md |
+| 6 | Friend trial | beta cohort reviewed | friend_trial.md |
+| 7 | Cut release | RC automation + manual gates | PUBLIC_RELEASE_RUNBOOK.md |
+| 8 | Stores | (post-1.0 distribution) | STORE_SUBMISSIONS.md |
+
+Already closed (not gates you need to re-run): CI quality gates — lint, type
+check, full test suite, and webapp lint/type/tests all run on every push (see the
+tracker).

--- a/tests/test_release_docs.py
+++ b/tests/test_release_docs.py
@@ -77,8 +77,8 @@ def test_support_matrix_and_v1_release_target_define_first_class_surfaces():
         assert marker in release_target
 
     for marker in (
-        "Windows signing wired and verified",
-        "macOS signing + notarization wired and verified",
+        "Windows signing secrets set + signed build verified",
+        "macOS signing + notarization secrets set + verified",
         "Live timing baseline recorded",
         "Small friend/beta cohort reviewed",
         "continue shipping `0.x` releases",


### PR DESCRIPTION
## Summary

Tightens the v1.0 readiness docs so the remaining external gates are turnkey when you're ready to drive toward 1.0. **Docs-only** (plus one doc-test marker update). Calibrated lean/durable per the interview ("tidying for when I get there").

### The four tracks
- **`docs/V1_RELEASE_FLOW.md` (new)** — a single ordered entry point chaining `target → tracker → signing → timing → per-OS FTUX → friend trial → release runbook → store submissions`, with an at-a-glance step/gate/doc table. It's an index — it links the authoritative docs rather than duplicating them.
- **`docs/V1_READINESS_TRACKER.md`** — marks the **CI quality gates done** (lint/type/full-suite + webapp lint/type/tests, closed by #26/#29/#31), splits the signing gate into "**wiring exists** (done)" vs "**secrets set + verified** (open)", adds a **friend-trial friction-log table**, and links the flow index + per-OS checklist.
- **`docs/SIGNING.md`** — reconciled with reality. It previously said to "uncomment env vars" and listed **wrong secret names**; in fact `installer_build.yml` is **already wired** to consume signing secrets (unsigned without them, signed with them). Fixes:
  - correct secret names CI actually reads (`APPLE_CERTIFICATE`, `APPLE_APP_SPECIFIC_PASSWORD`, `WINDOWS_CERTIFICATE*`)
  - clarifies `TAURI_SIGNING_PRIVATE_KEY` is the **updater minisign** key, not Authenticode
  - adds "find the signing identity" + "verify a signed build" steps (`spctl` / `Get-AuthenticodeSignature`)
  - a **Windows cert options matrix** (unsigned / OV / EV / Azure Trusted Signing) with a recommendation, since the path isn't chosen yet
- **`docs/RC_RELEASE_RUNBOOK.md`** — deprecation banner pointing to the current installer-based runbook + the flow index (it's the legacy tarball process).

## Test plan
- [x] `pytest tests/` → **705 passed, 3 skipped** (updated 2 gate-label markers in `test_release_docs.py` to match the refined tracker wording)
- [x] All cross-doc links resolve (verified every linked path exists)

## Note
The two signing gates stay **open** — this PR makes them *executable* (correct secrets + verification steps), it doesn't set any secrets. Windows signing direction is deliberately left as an options matrix for you to choose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9)_