### PR TITLE
chore(stores): 0.2.3 store metadata — WinGet manifest + Homebrew + Flathub

### DIFF
--- a/docs/STORE_SUBMISSIONS.md
+++ b/docs/STORE_SUBMISSIONS.md
@@ -14,7 +14,7 @@ are not yet live. Full per-channel steps follow below.
 |---|---|---|
 | WinGet | ✅ Live | Per-release: `./scripts/update_winget_manifest.sh <version>` then PR |
 | Snap Store | ✅ Live | Auto-publishes on `v*` tag via `snap_publish.yml` |
-| Homebrew Cask | 🟡 Ready, blocked on macOS notarization | Notarize the `.dmg` (needs Apple Developer Program), then submit the PR — formula SHA256s for 0.2.2 are already filled in |
+| Homebrew Cask | 🟡 Ready, blocked on macOS notarization | Notarize the `.dmg` (needs Apple Developer Program), then submit the PR — formula SHA256s for 0.2.3 are already filled in |
 | Flathub | 🟡 Ready, needs deps JSON | Run `./scripts/gen_flatpak_deps.sh`, set the real commit SHA in the manifest, then submit the PR — screenshots in the metainfo are already populated |
 | Microsoft Store | 🟡 Ready, blocked on Partner Center | Register Partner Center ($19), replace the `TODO(partner-center)` Identity/Publisher in `packaging/msix/Package.appxmanifest`, convert the NSIS `.exe` to MSIX, upload |
 
@@ -74,7 +74,7 @@ Required for: Microsoft Store submission.
 
 1. Download the notarized `.dmg` files for both architectures from the GitHub Release
 2. Confirm the `sha256` values in the formula match the released `.dmg` files (already
-   filled in for 0.2.2; recompute with `shasum -a 256 <file>.dmg` for new releases)
+   filled in for 0.2.3; recompute with `shasum -a 256 <file>.dmg` for new releases)
 3. Fork https://github.com/Homebrew/homebrew-cask
 4. Copy the formula to `Casks/s/spinner-for-discogs.rb`
 5. Run locally: `brew install --cask ./Casks/s/spinner-for-discogs.rb`

--- a/packaging/flatpak/com.discogs-spinner.app.yml
+++ b/packaging/flatpak/com.discogs-spinner.app.yml
@@ -65,5 +65,5 @@ modules:
       - type: git
         url: https://github.com/edonahue/Discogs_Spinner.git
         # Replace with the exact tag or commit SHA for each release
-        tag: v0.2.2
-        commit: PLACEHOLDER_COMMIT_SHA_REPLACE_BEFORE_SUBMISSION
+        tag: v0.2.3
+        commit: 0b3e01a73c5db20a8810c600975e8ee295579e10

--- a/packaging/homebrew/spinner-for-discogs.rb
+++ b/packaging/homebrew/spinner-for-discogs.rb
@@ -7,18 +7,18 @@
 # 4. Run: brew audit --cask --new spinner-for-discogs
 #
 cask "spinner-for-discogs" do
-  version "0.2.2"
+  version "0.2.3"
 
   on_arm do
     url "https://github.com/edonahue/Discogs_Spinner/releases/download/v#{version}/Discogs.Spinner_#{version}_aarch64.dmg",
         verified: "github.com/edonahue/Discogs_Spinner/"
-    sha256 "122b8d29aee2bd5c3988239bcd1c7a42858a1fc2e061acf960086635c3e3a088"
+    sha256 "73e9aa70874d28a8b8eed736ccf4143a238e5359d13eaae251993787f02301de"
   end
 
   on_intel do
     url "https://github.com/edonahue/Discogs_Spinner/releases/download/v#{version}/Discogs.Spinner_#{version}_x64.dmg",
         verified: "github.com/edonahue/Discogs_Spinner/"
-    sha256 "a4ed2b0e08bf4ddeffcd14bdb68bc56e62fab58211c4d8f1d78a859567f3befa"
+    sha256 "74dd23f7c8a2f345f740c95684312357433280942088a8e6580bd028b4364817"
   end
 
   name "Spinner for Discogs"

--- a/packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.2.3/ErichDonahue.SpinnerforDiscogs.installer.yaml
+++ b/packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.2.3/ErichDonahue.SpinnerforDiscogs.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: ErichDonahue.SpinnerforDiscogs
+PackageVersion: 0.2.3
+MinimumOSVersion: "10.0.17763.0"
+InstallerType: nullsoft
+InstallModes:
+  - interactive
+  - silent
+UpgradeBehavior: install
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/edonahue/Discogs_Spinner/releases/download/v0.2.3/Discogs.Spinner_0.2.3_x64-setup.exe
+    InstallerSha256: 3eb076af62b928d4701b6ab479cdf21dbc034fd9c221ce0a18a457568a2ae8e7
+    InstallerType: nullsoft
+  - Architecture: x64
+    InstallerUrl: https://github.com/edonahue/Discogs_Spinner/releases/download/v0.2.3/Discogs.Spinner_0.2.3_x64_en-US.msi
+    InstallerSha256: d38030f62d43c7fcf5e7be097ddafbc05cb6dca3be8087586ecddced9882eee5
+    InstallerType: wix
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.2.3/ErichDonahue.SpinnerforDiscogs.locale.en-US.yaml
+++ b/packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.2.3/ErichDonahue.SpinnerforDiscogs.locale.en-US.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: ErichDonahue.SpinnerforDiscogs
+PackageVersion: 0.2.3
+PackageLocale: en-US
+Publisher: Erich Donahue
+PublisherUrl: https://github.com/edonahue
+PublisherSupportUrl: https://github.com/edonahue/Discogs_Spinner/issues
+PackageName: Spinner for Discogs
+PackageUrl: https://github.com/edonahue/Discogs_Spinner
+License: MIT
+LicenseUrl: https://github.com/edonahue/Discogs_Spinner/blob/main/LICENSE
+Copyright: Copyright (c) Erich Donahue
+ShortDescription: Third-party Discogs collection browser and Spotify playback controller
+Description: |-
+  Spinner for Discogs is an unofficial third-party desktop client for Discogs.
+  Browse your vinyl collection, discover wantlist picks, and control Spotify
+  or YouTube Music playback — all from a single desktop app.
+  Requires a free Discogs Personal Access Token from discogs.com/settings/developers.
+Moniker: spinner-for-discogs
+Tags:
+  - discogs
+  - vinyl
+  - music
+  - collection
+  - spotify
+  - record
+ReleaseNotesUrl: https://github.com/edonahue/Discogs_Spinner/releases/tag/v0.2.3
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.2.3/ErichDonahue.SpinnerforDiscogs.yaml
+++ b/packaging/winget/manifests/e/ErichDonahue/SpinnerforDiscogs/0.2.3/ErichDonahue.SpinnerforDiscogs.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: ErichDonahue.SpinnerforDiscogs
+PackageVersion: 0.2.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary

Brings all store metadata current for the published **v0.2.3** release.

### WinGet (new 0.2.3 manifest)
`packaging/winget/manifests/.../0.2.3/`, generated by `update_winget_manifest.sh`. The script couldn't auto-fill SHA256s (CHECKSUMS lists `Discogs Spinner_…` with a space, assets use `Discogs.Spinner_…` with dots), so the `InstallerSha256` values were filled manually and **verified against the live assets**:
- `x64-setup.exe` (nullsoft) → `3eb076af…2ae8e7`
- `x64_en-US.msi` (wix) → `d38030f6…82eee5`

### Homebrew cask → 0.2.3
`version` 0.2.2 → 0.2.3 with the new `.dmg` SHA256s (GitHub asset digests confirm they match CHECKSUMS): aarch64 `73e9aa70…`, x64 `74dd23f7…`.

### Flathub manifest → 0.2.3
`tag: v0.2.2 → v0.2.3` and the `PLACEHOLDER` commit → the real v0.2.3 tag commit `0b3e01a`.

Plus `STORE_SUBMISSIONS.md` homebrew SHA note 0.2.2 → 0.2.3.

## Status
- **WinGet** — manifest ready; remaining: copy into a `microsoft/winget-pkgs` fork + submit (external).
- **Homebrew / Flathub** — metadata now current but still externally gated (notarization / `python3-deps.json` respectively) before their submission PRs.

## Test plan
- [x] `pytest tests/` → 705 passed, 3 skipped
- [x] WinGet SHA256s verified by hashing the downloaded `.exe`/`.msi`; dmg hashes cross-checked against the release API asset digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kxz9esTMpWkEcvXiDKuEU9